### PR TITLE
Fix NPE when bP.minOccurs == null

### DIFF
--- a/core/src/main/groovy/com/predic8/schema/diff/SequenceDiffGenerator.groovy
+++ b/core/src/main/groovy/com/predic8/schema/diff/SequenceDiffGenerator.groovy
@@ -69,7 +69,7 @@ class SequenceDiffGenerator  extends UnitDiffGenerator {
     def diffs = []
     (b.particles-bPs).eachWithIndex() { bP, i ->
         def minOccurs = 1;
-        if (bP.hasProperty('minOccurs')) { minOccurs = Integer.valueOf(bP.minOccurs); }
+        if (bP.hasProperty('minOccurs') && bP.minOccurs) { minOccurs = Integer.valueOf(bP.minOccurs); }
 
         if(a.elements.find{it.name == bP.name}) {
         diffs << new Difference(description:"Position of element ${bP.name} changed." , type: 'sequence', breaks: true, safe: false)


### PR DESCRIPTION
Small fix, I didn't realize that I'd broken a couple tests in SequenceDiffGeneratorTest with an unsafe dereference.  This gets all tests passing again.
