### PR TITLE
Added support for conditionally disabling tests that require an active internet connection

### DIFF
--- a/core/src/test/groovy/com/predic8/wsdl/diff/DocumentationDiffGeneratorTest.groovy
+++ b/core/src/test/groovy/com/predic8/wsdl/diff/DocumentationDiffGeneratorTest.groovy
@@ -13,23 +13,29 @@ package com.predic8.wsdl.diff
 
 import com.predic8.wsdl.*
 import com.predic8.xml.util.*
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
 
-class DocumentationDiffGeneratorTest extends GroovyTestCase {
+class DocumentationDiffGeneratorTest {
 
 	Definitions wsdl1 //original wsdl
 	Definitions wsdl2 //local wsdl with documentation
 
+    @Before
 	void setUp() {
+        Assume.assumeTrue(!System.getenv('OFFLINETESTING'))
 		def parser = new WSDLParser()
 		wsdl1 = parser.parse('http://www.thomas-bayer.com/axis2/services/BLZService?wsdl')
 		parser.resourceResolver = new ClasspathResolver()
 		wsdl2 = parser.parse("BLZService-with-documentation.wsdl")
 	}
 
+    @Test
 	void testDocumentationInDefinitions() {
 		def diffs = compare(wsdl1, wsdl2)
-		assertEquals(6, diffs*.dump().toString().count('Documentation added.'))
-		assertEquals(1, diffs*.dump().toString().count('Documentation has changed.'))
+		assert 6 == diffs*.dump().toString().count('Documentation added.')
+		assert 1 == diffs*.dump().toString().count('Documentation has changed.')
 	}
 
 	private def compare(a, b) {

--- a/core/src/test/groovy/com/predic8/wsdl/diff/OperationDiffGeneratorTest.groovy
+++ b/core/src/test/groovy/com/predic8/wsdl/diff/OperationDiffGeneratorTest.groovy
@@ -13,19 +13,25 @@ package com.predic8.wsdl.diff
 
 import com.predic8.wsdl.*
 import com.predic8.xml.util.*
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
 
-class OperationDiffGeneratorTest extends GroovyTestCase {
+class OperationDiffGeneratorTest {
 
 	Definitions wsdl1 
 	Definitions wsdl2 
 
+    @Before
 	void setUp() {
+        Assume.assumeTrue(!System.getenv('OFFLINETESTING'))
 		def parser = new WSDLParser()
 		wsdl1 = parser.parse('http://www.thomas-bayer.com/axis2/services/BLZService?wsdl')
 		parser.resourceResolver = new ClasspathResolver()
 		wsdl2 = parser.parse("BLZService-with-documentation.wsdl")
 	}
 
+    @Test
 	void testOperationInput() {
 		def diffs = compare(wsdl1, wsdl2)
 		assert diffs[0].diffs[1].diffs[1].diffs[1].description == 'Input:'
@@ -37,7 +43,8 @@ class OperationDiffGeneratorTest extends GroovyTestCase {
 		assert diffs[0].diffs[1].diffs[1].diffs[1].diffs[1].diffs[0].description == 'Documentation added.'
 		assert !diffs[0].diffs[1].diffs[1].diffs[1].diffs[1].diffs[0].breaks()
 	}
-	
+
+    @Test
 	void testOperationOutput() {
 		def diffs = compare(wsdl1, wsdl2)
 		assert diffs[0].diffs[1].diffs[1].diffs[2].description == 'Output:'

--- a/core/src/test/groovy/com/predic8/wstool/creator/SOARequestCreatorWithCreatedWSDLTest.groovy
+++ b/core/src/test/groovy/com/predic8/wstool/creator/SOARequestCreatorWithCreatedWSDLTest.groovy
@@ -7,13 +7,19 @@ import com.predic8.schema.restriction.StringRestriction;
 import com.predic8.wsdl.*
 import com.predic8.wsdl.creator.WSDLCreator
 import com.predic8.wsdl.creator.WSDLCreatorContext
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+
 import static com.predic8.schema.Schema.*;
 
-class SOARequestCreatorWithCreatedWSDLTest extends GroovyTestCase{
+class SOARequestCreatorWithCreatedWSDLTest {
 
   Definitions wsdl
 
+  @Before
   void setUp(){
+    Assume.assumeTrue(!System.getenv('OFFLINETESTING'))
     WSDLParser parser = new WSDLParser()
     wsdl = parser.parse("http://www.thomas-bayer.com/axis2/services/BLZService?wsdl")
     addOperation()
@@ -39,15 +45,17 @@ class SOARequestCreatorWithCreatedWSDLTest extends GroovyTestCase{
     bo.newOutput().newSOAP11Body();
   }
 
+  @Test
   void testDefinitions(){
-    assertEquals(2, wsdl.getBinding('BLZServiceSOAP11Binding').operations.size())
+    assert 2 == wsdl.getBinding('BLZServiceSOAP11Binding').operations.size()
   }
-  
+
+  @Test
   void testSOARequest(){
     StringWriter writer = new StringWriter()
     SOARequestCreator creator = new SOARequestCreator(wsdl, new RequestTemplateCreator(), new MarkupBuilder(writer))
     creator.createRequest("BLZServicePortType", "listBanks", "BLZServiceSOAP11Binding")
-    assertEquals('listBanks', new XmlSlurper().parseText(writer.toString()).Envelope.body.listBanks.name())
+    assert 'listBanks' == new XmlSlurper().parseText(writer.toString()).Envelope.body.listBanks.name()
   }
   
 }

--- a/core/src/test/groovy/com/predic8/xml/util/ExternalResolverTest.groovy
+++ b/core/src/test/groovy/com/predic8/xml/util/ExternalResolverTest.groovy
@@ -14,19 +14,24 @@
 
 package com.predic8.xml.util
 
-import junit.framework.TestCase
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
 
-class ExternalResolverTest extends GroovyTestCase {
+class ExternalResolverTest {
   
 	def resolver
 	def url
-	
+
+    @Before
 	void setUp() {
-		resolver = new ExternalResolver()
-		url = 'http://www.thomas-bayer.com/axis2/services/BLZService?wsdl'
+	  resolver = new ExternalResolver()
+	  url = 'http://www.thomas-bayer.com/axis2/services/BLZService?wsdl'
 	}
-	
-  void testResolveAsString() {
-		assertNotNull(resolver.resolveAsString(url))
-	}
+
+   @Test
+   void testResolveAsString() {
+     Assume.assumeTrue(!System.getenv('OFFLINETESTING'))
+     assert resolver.resolveAsString(url) != null
+   }
 }


### PR DESCRIPTION
Some of the tests require an active internet connection and access to www.thomas-bayer.com . Our build server does not allow arbitrary outgoing connections.

To still allow building and testing the core module I added support to ignore the tests that require a connection to www.thomas-bayer.com at runtime by adding an environment variable OFFLINETESTING with a non empty value.

Using org.junit.Assume did require to make those tests jUnit 4 style, using the test annotations and not extending GroovyTestCase.
