### PR TITLE
#194 Avoiding wrong exchange matching in WsdlDiffGenerator.comparePortTypes

### DIFF
--- a/core/src/main/groovy/com/predic8/wsdl/diff/WsdlDiffGenerator.groovy
+++ b/core/src/main/groovy/com/predic8/wsdl/diff/WsdlDiffGenerator.groovy
@@ -182,10 +182,10 @@ class WsdlDiffGenerator extends AbstractDiffGenerator{
 		def diffs = []
 		def faults = aFaults.message.qname.intersect(bFaults.message.qname)
 		(aFaults.message.qname - faults).each {
-			diffs << new Difference(description:"Fault with message ${it} removed.", type: 'fault', exchange:exchange.clone())
+			diffs << new Difference(description:"Fault with message ${it} removed.", type: 'fault', exchange:exchange)
 		}
 		(bFaults.message.qname - faults).each {
-			diffs << new Difference(description:"Fault with message ${it} added.", type: 'fault', exchange:exchange.clone())
+			diffs << new Difference(description:"Fault with message ${it} added.", type: 'fault', exchange:exchange)
 		}
 		faults.each { f ->
 			diffs.addAll(comparePortTypeMessage(aFaults.find{it.message.name == f}, bFaults.find{it.message.name == f}, exchange))
@@ -197,7 +197,7 @@ class WsdlDiffGenerator extends AbstractDiffGenerator{
 		def diffs = compareDocumentation(a, b)
 		diffs.addAll( compareParts(a.parts, b.parts, exchange))
 		if(diffs) return [
-				new Difference(description:"Message${(a.name == b.name)? ' '+a.name : ''}:", type: 'message', diffs : diffs, exchange:exchange.clone())
+				new Difference(description:"Message${(a.name == b.name)? ' '+a.name : ''}:", type: 'message', diffs : diffs, exchange:exchange)
 			]
 		[]
 	}


### PR DESCRIPTION
Since ['fault'] does not match any of the switch cases in  WsdlDiffGenerator.comparePortTypes exchange is null.
