### PR TITLE
Compare performance improvements through caching

### DIFF
--- a/core/src/main/groovy/com/predic8/schema/Schema.groovy
+++ b/core/src/main/groovy/com/predic8/schema/Schema.groovy
@@ -70,6 +70,8 @@ class Schema extends SchemaComponent{
   List<AttributeGroup> attributeGroups = []
 
   final Map<QName, TypeDefinition> getTypeCache = [:]
+
+  @Lazy List<Schema> allSchemasCache = { [this] + importedSchemas }.call()
   
   Schema(){}
   
@@ -257,8 +259,9 @@ class Schema extends SchemaComponent{
     }
   }
 
+
   List<Schema> getAllSchemas(){
-    [this] + importedSchemas
+    allSchemasCache
   }
 	
   List<Schema> getImportedSchemas(){

--- a/core/src/main/groovy/com/predic8/wsdl/Types.groovy
+++ b/core/src/main/groovy/com/predic8/wsdl/Types.groovy
@@ -14,15 +14,12 @@
 
 package com.predic8.wsdl
 
-import groovy.xml.QName
-
 import javax.xml.namespace.QName as JQName
 
 import org.apache.commons.logging.*
 
 import com.predic8.schema.*
 import com.predic8.soamodel.*
-import com.predic8.xml.util.*
 
 class Types extends WSDLElement {
 
@@ -30,6 +27,8 @@ class Types extends WSDLElement {
   public static final JQName ELEMENTNAME = new JQName(Consts.WSDL11_NS, 'types')
   
   List<Schema> schemas = []
+
+  @Lazy List<Schema> allSchemasCache = {schemas*.allSchemas.flatten().unique()}.call()
   
   protected parseChildren(token, child, WSDLParserContext ctx){
     super.parseChildren(token, child, ctx)
@@ -44,7 +43,7 @@ class Types extends WSDLElement {
   }
 
   List<Schema> getAllSchemas() {
-		(schemas + schemas.importedSchemas.flatten()).unique()
+    allSchemasCache
   }
 
   void create(AbstractCreator creator, CreatorContext ctx){


### PR DESCRIPTION
Some more aggressive performance improvements for the compare algorithm through caching the getAllSchemas() result.
- The result for Schema.getAllSchemas() and Types.getAllSchemas() is cached
- Looking up a TypeDefinition in a Schema tree is cached 

For our WSDLs who pull in a lot of Schemas this results in a 90% speedup. Our longest running WSDL comparison went from taking 90 seconds to taking 8 seconds after these improvements.
