### PR TITLE
Update ExternalResolver.groovy

### DIFF
--- a/core/src/main/groovy/com/predic8/xml/util/ExternalResolver.groovy
+++ b/core/src/main/groovy/com/predic8/xml/util/ExternalResolver.groovy
@@ -88,7 +88,7 @@ class ExternalResolver extends ResourceResolver {
 
 	protected resolveViaHttp(url) {
 		URI uri = new URI(url)
-		uri.normalize()
+		uri = uri.normalize()
 		new StringReader(resolveAsString(uri.toString()))
 	}
 


### PR DESCRIPTION
Instances of URI are immutable.  The normalize returns the normalized URI but does not modify the existing URI.

You have to re-set the uri variable with the new normalized URI that is returned from normalize()
