### PR TITLE
update groovy-eclipse-compiler to newest version (2.9.1-01)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,7 +107,7 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.1</version>
 				<configuration>
 					<compilerId>groovy-eclipse-compiler</compilerId>
 					<verbose>true</verbose>
@@ -118,15 +118,20 @@
 					<dependency>
 						<groupId>org.codehaus.groovy</groupId>
 						<artifactId>groovy-eclipse-compiler</artifactId>
-						<version>2.7.0-01</version>
+						<version>2.9.1-01</version>
+					</dependency>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-eclipse-batch</artifactId>
+						<version>2.3.7-01</version>
 					</dependency>
 				</dependencies>
 			</plugin>
-
+			
 			<plugin>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-eclipse-compiler</artifactId>
-				<version>2.7.0-01</version>
+				<version>2.9.1-01</version>
 				<extensions>true</extensions>
 			</plugin>
 


### PR DESCRIPTION
Another improvement could be deleting the eclipse files from git and re-enabling the "org.eclipse.m2e" plug-in.

I can sent another pull request for that if this is a welcome improvement.