### PR TITLE
Fixed handling of indexes in XPath when filling forms during SOAP request generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ temp
 */.classpath
 */.project
 */.groovy
-
+.idea
+*.iml

--- a/core/src/main/groovy/com/predic8/wstool/creator/RequestCreator.groovy
+++ b/core/src/main/groovy/com/predic8/wstool/creator/RequestCreator.groovy
@@ -124,7 +124,7 @@ class RequestCreator extends AbstractSchemaCreator<RequestCreatorContext> {
   public getElementXpaths(ctx){
     def es = []
     ctx.formParams.keySet().each {
-      def e = it =~ /${ctx.path}${ctx.element.name}\/.*?/
+      def e = it =~ /${ctx.path}${ctx.element.name}(?:\[\d+\])*\/.*?/
       if (e)  es << e[0]
     }
     es.unique()

--- a/core/src/test/groovy/com/predic8/wstool/creator/RequestCreatorTest.groovy
+++ b/core/src/test/groovy/com/predic8/wstool/creator/RequestCreatorTest.groovy
@@ -54,10 +54,10 @@ class RequestCreatorTest extends GroovyTestCase{
     assertEquals('30', request.employee[0].@age.toString())
 	assertEquals('programer', request.employee[0].department.activity.text())
 	assertEquals('predic8', request.employee[0].department.company.text())
-	//assertEquals('Angela', request.employee[1].firstName.text())
-	//assertEquals('Iron Chancellor', request.employee[1].department.activity.text())
-	////The value of 'company' is fixed on 'predic8'. The given value 'BRD' will be ignored!
-	//assertEquals('predic8', request.employee[1].department.company.text())
+	assertEquals('Angela', request.employee[1].firstName.text())
+	assertEquals('Iron Chancellor', request.employee[1].department.activity.text())
+	//The value of 'company' is fixed on 'predic8'. The given value 'BRD' will be ignored!
+	assertEquals('predic8', request.employee[1].department.company.text())
   }
   
   void testCreatRequestWithRefType() {
@@ -82,6 +82,6 @@ class RequestCreatorTest extends GroovyTestCase{
     def ctx = new RequestCreatorContext(formParams:formParams)
     ctx.path = "xpath:/employeeList/"
     ctx.element = schema.getElement('employee')
-    //assertEquals(['xpath:/employeeList/employee/', 'xpath:/employeeList/employee[1]/', 'xpath:/employeeList/employee[2]/'], creator.getElementXpaths(ctx))
+    assertEquals(['xpath:/employeeList/employee/', 'xpath:/employeeList/employee[1]/', 'xpath:/employeeList/employee[2]/'], creator.getElementXpaths(ctx))
   }
 }


### PR DESCRIPTION
1. Fixed handling of indexes in XPath, e.g.
xpath:/DisconnectSubscriberOfferSrvcRequest/RequestBody/OfferKey[1]/OfferId

2. Uncommented test cases for #1

3. Ignored IntelliJ IDEA files