### PR TITLE
Added testcases demonstrating wrong behavior with nested WSDLs.

### DIFF
--- a/core/src/test/groovy/com/predic8/wsdl/diff/WsdlDiffGeneratorTest.groovy
+++ b/core/src/test/groovy/com/predic8/wsdl/diff/WsdlDiffGeneratorTest.groovy
@@ -86,6 +86,40 @@ class WsdlDiffGeneratorTest extends GroovyTestCase {
 		assert diffs*.dump().toString().contains('Binding ProjectServiceTestBinding added.')
   }
 
+  /**
+   * Compare top level WSDLs. WsdlDiffGenerator see NO changes at all.
+   */
+  void testCompareThreeLevelNestedWsdl() {
+    def parser = new WSDLParser(resourceResolver: new ClasspathResolver())
+
+    Definitions wsdlOld = parser.parse('/wsdl/multiple-files-same-namespace-nested/old/TestParent.wsdl')
+    Definitions wsdlNew = parser.parse('/wsdl/multiple-files-same-namespace-nested/new/TestParent.wsdl')
+
+    def diffs = compare(wsdlOld, wsdlNew)
+
+    // Expected diffs:
+    // wsdl/new/TestParent.wsdl: has import City.xsd
+    // wsdl/new/TestParent.wsdl: Branch.xsd declares 'newField'
+    assert diffs.size() == 2
+  }
+
+  /**
+   * Compare nested WSDLs. WsdlDiffGenerator doesn't see City.xsd inclusion.
+   */
+  void testCompareTwoLevelNestedWsdl() {
+    def parser = new WSDLParser(resourceResolver: new ClasspathResolver())
+
+    Definitions wsdlOld = parser.parse('/wsdl/multiple-files-same-namespace-nested/old/Test.wsdl')
+    Definitions wsdlNew = parser.parse('/wsdl/multiple-files-same-namespace-nested/new/Test.wsdl')
+
+    def diffs = compare(wsdlOld, wsdlNew)
+
+    // Expected diffs:
+    // wsdl/new/TestParent.wsdl: has import City.xsd
+    // wsdl/new/TestParent.wsdl: Branch.xsd declares 'newField'
+    assert diffs.size() == 2
+  }
+
   private def compare(a, b) {
     new WsdlDiffGenerator(a: a, b: b).compare()
   }

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/Branch.xsd
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/Branch.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://TestEngineLib"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:complexType name="Branch">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="name" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="city" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="address" type="xsd:string"/>
+
+            <xsd:element minOccurs="0" name="newField" type="xsd:boolean"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/City.xsd
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/City.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://TestEngineLib"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:complexType name="City">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="city" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="region" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/Test.wsdl
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/Test.wsdl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestInterface" targetNamespace="http://TestEngineLib/TestInterface"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://TestEngineLib/TestInterface" xmlns:bons1="http://TestEngineLib">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://TestEngineLib/TestInterface">
+            <xsd:import namespace="http://TestEngineLib" schemaLocation="Branch.xsd"/>
+            <xsd:import namespace="http://TestEngineLib" schemaLocation="City.xsd"/>
+
+            <xsd:element name="branch">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="request" nillable="true" type="bons1:Branch"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="branchResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="response" nillable="true" type="bons1:Branch"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="branchRequestMsg">
+        <wsdl:part name="accountToExternalTestParameters" element="tns:branch">
+        </wsdl:part>
+    </wsdl:message>
+
+    <wsdl:message name="branchResponseMsg">
+        <wsdl:part name="cardToCreditTestResult" element="tns:branchResponse"></wsdl:part>
+    </wsdl:message>
+
+    <wsdl:portType name="TestInterface">
+        <wsdl:operation name="branch">
+            <wsdl:input name="branchRequest" message="tns:branchRequestMsg">
+            </wsdl:input>
+            <wsdl:output name="branchResponse" message="tns:branchResponseMsg">
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:portType>
+</wsdl:definitions>

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/TestParent.wsdl
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/new/TestParent.wsdl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestInterfaceExport1_TestInterfaceHttp_Service" targetNamespace="http://TestEngineLib/TestInterface/Binding" xmlns:Port_0="http://TestEngineLib/TestInterface" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:this="http://TestEngineLib/TestInterface/Binding" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+  <wsdl:import namespace="http://TestEngineLib/TestInterface" location="Test.wsdl">
+    </wsdl:import>
+  <wsdl:binding name="TestInterfaceExport1_TestInterfaceHttpBinding" type="Port_0:TestInterface">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="branch">
+      <soap:operation soapAction="http://TestEngineLib/TestInterface/Binding/test"/>
+      <wsdl:input name="branchRequest">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="branchResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="TestInterfaceExport1_TestInterfaceHttpService">
+    <wsdl:port name="TestInterfaceExport_TestInterfaceHttpPort" binding="this:TestInterfaceExport1_TestInterfaceHttpBinding">
+      <soap:address location="http://localhost/TestEngineModuleWeb/sca/TestInterfaceExport"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/old/Branch.xsd
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/old/Branch.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://TestEngineLib"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<xsd:complexType name="Branch">
+		<xsd:sequence>
+			<xsd:element minOccurs="0" name="name" type="xsd:string"/>
+			<xsd:element minOccurs="0" name="city" type="xsd:string"/>
+			<xsd:element minOccurs="0" name="address" type="xsd:string"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/old/Test.wsdl
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/old/Test.wsdl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestInterface" targetNamespace="http://TestEngineLib/TestInterface"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://TestEngineLib/TestInterface" xmlns:bons1="http://TestEngineLib">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://TestEngineLib/TestInterface">
+            <xsd:import namespace="http://TestEngineLib" schemaLocation="Branch.xsd"/>
+
+            <xsd:element name="branch">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="request" nillable="true" type="bons1:Branch"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="branchResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="response" nillable="true" type="bons1:Branch"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="branchRequestMsg">
+        <wsdl:part name="accountToExternalTestParameters" element="tns:branch">
+        </wsdl:part>
+    </wsdl:message>
+
+    <wsdl:message name="branchResponseMsg">
+        <wsdl:part name="cardToCreditTestResult" element="tns:branchResponse">
+
+        </wsdl:part>
+    </wsdl:message>
+
+    <wsdl:portType name="TestInterface">
+        <wsdl:operation name="branch">
+            <wsdl:input name="branchRequest" message="tns:branchRequestMsg">
+            </wsdl:input>
+            <wsdl:output name="branchResponse" message="tns:branchResponseMsg">
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:portType>
+</wsdl:definitions>

--- a/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/old/TestParent.wsdl
+++ b/core/src/test/resources/wsdl/multiple-files-same-namespace-nested/old/TestParent.wsdl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestInterfaceExport1_TestInterfaceHttp_Service" targetNamespace="http://TestEngineLib/TestInterface/Binding" xmlns:Port_0="http://TestEngineLib/TestInterface" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:this="http://TestEngineLib/TestInterface/Binding" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/">
+  <wsdl:import namespace="http://TestEngineLib/TestInterface" location="Test.wsdl">
+    </wsdl:import>
+  <wsdl:binding name="TestInterfaceExport1_TestInterfaceHttpBinding" type="Port_0:TestInterface">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="branch">
+      <soap:operation soapAction="http://TestEngineLib/TestInterface/Binding/test"/>
+      <wsdl:input name="branchRequest">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="branchResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="TestInterfaceExport1_TestInterfaceHttpService">
+    <wsdl:port name="TestInterfaceExport_TestInterfaceHttpPort" binding="this:TestInterfaceExport1_TestInterfaceHttpBinding">
+      <soap:address location="http://localhost/TestEngineModuleWeb/sca/TestInterfaceExport"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Created two sets of WSDLs (new and old): 
      
    soa-model/core/src/test/resources/wsdl/multiple-files-same-namespace-nested

Structure:

    TestParent.wsdl
      Test.wsdl
         *.xsd

Differences:
1. new: Test.wsdl imports City.xsd
2. new: Branch.xsd declares 'newField'

Cases:
1. compare(old/Test.wsdl, new/Test.wsdl) sees diff 2 but misses diff 1
2. compare(old/TestParent.wsdl, new/TestParent.wsdl) see NO diffs at all