### PR TITLE
fixed bug inFormCreator (htmlformcreator), nullpointerexception

### DIFF
--- a/core/src/main/groovy/com/predic8/wstool/creator/FormCreator.groovy
+++ b/core/src/main/groovy/com/predic8/wstool/creator/FormCreator.groovy
@@ -209,7 +209,7 @@ class FormCreator extends AbstractSchemaCreator <FormCreatorContext>{
     } else if(res.minLengthFacet) {
       ctx.attrs['label'] = "Should be at least ${res.minLengthFacet.value} characters."
     } else if(res.maxLengthFacet){
-      ctx.attrs['label'] = "Should have at most ${res.minLengthFacet.value} characters."
+      ctx.attrs['label'] = "Should have at most ${res.maxLengthFacet.value} characters."
     }
     //@todo Patternfacet, maxInclusive, lengthFacet must be implemented! 
     if(ctx.element) {

--- a/core/src/main/groovy/com/predic8/wstool/creator/FormCreator.groovy
+++ b/core/src/main/groovy/com/predic8/wstool/creator/FormCreator.groovy
@@ -192,7 +192,7 @@ class FormCreator extends AbstractSchemaCreator <FormCreatorContext>{
     } else if(res.minLengthFacet) {
       ctx.attrs['label'] = "Should be at least ${res.minLengthFacet.value} characters."
     } else if(res.maxLengthFacet){
-      ctx.attrs['label'] = "Should have at most ${res.minLengthFacet.value} characters."
+      ctx.attrs['label'] = "Should have at most ${res.maxLengthFacet.value} characters."
     }
     if(ctx.element) {
       writeInputField(ctx.element ,  ctx)


### PR DESCRIPTION
When using the FormCreator to create a htmlform we got a nullpointerexception when a restriction only had a maxLength. This happened because of a small bug in the createStringRestriction method in FormCreator. 
