### PR TITLE
Fixed a bug handling minOccurs and maxOccurs in the GroupRef object.

### DIFF
--- a/core/src/main/groovy/com/predic8/schema/GroupRef.groovy
+++ b/core/src/main/groovy/com/predic8/schema/GroupRef.groovy
@@ -26,8 +26,13 @@ import javax.xml.stream.*
 class GroupRef extends SchemaComponent{
 
   QName ref
-  def minOccurs
-  def maxOccurs
+  def minOccurs = 1
+  def maxOccurs = 1
+  
+  protected parseAttributes(token, params){
+	minOccurs = token.getAttributeValue( null , 'minOccurs') ?: 1
+	maxOccurs = token.getAttributeValue( null , 'maxOccurs') ?: 1
+  }
 
   def create(creator, CreatorContext ctx){
     creator.createGroupRef(this, ctx)


### PR DESCRIPTION
Before the GroupRef class did not parse the minOccurs and maxOccurs attributes. 
Furthermore it always returned null as minOccur and maxOccur.
This was fixed by setting 1 as default for minOccur and maxOccur as well as implementing the parseAttributes method as it was done in the ModelGroup class.