### PR TITLE
Fixed an issue with nested xml unbounded sequences

### DIFF
--- a/core/src/main/groovy/com/predic8/wstool/creator/RequestCreator.groovy
+++ b/core/src/main/groovy/com/predic8/wstool/creator/RequestCreator.groovy
@@ -124,8 +124,11 @@ class RequestCreator extends AbstractSchemaCreator<RequestCreatorContext> {
   public getElementXpaths(ctx){
     def es = []
     ctx.formParams.keySet().each {
-      def e = it =~ /${ctx.path}${ctx.element.name}(?:\[\d+\])*\/.*?/
-      if (e)  es << e[0]
+		def wholePath = "${ctx.path}${ctx.element.name}";
+		wholePath = wholePath.replaceAll(/\[/, "\\\\[");
+		wholePath = wholePath.replaceAll(/\]/, "\\\\]");
+		def e = it =~ /$wholePath(?:\[\d+\])*\/.*?/
+		if (e)  es << e[0]
     }
     es.unique()
   }


### PR DESCRIPTION
For example, with paths like "xpath:/create/article[1]/price[2]/amount"
This fixes the sample @
https://github.com/membrane/soa-model/blob/master/distribution/src/main/java/samples/wsdl/CreateSOAPRequest.java
that isn't working as of now.