### PR TITLE
add ns context to avoid ns overrides, update external resolver with ISO_8859_1 conversion, add ability to provide external XMLInputFactory

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-test</artifactId>
 			<scope>test</scope>
@@ -106,8 +110,8 @@
 				<configuration>
 					<compilerId>groovy-eclipse-compiler</compilerId>
 					<verbose>true</verbose>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/core/src/main/groovy/com/predic8/policy/PolicyParserContext.groovy
+++ b/core/src/main/groovy/com/predic8/policy/PolicyParserContext.groovy
@@ -23,7 +23,9 @@ class PolicyParserContext extends AbstractParserContext{
         input: args?.input,
         targetNamespace: args?.targetNamespace,
         importedSchemaCache: importedSchemaCache,
-        errors: errors)
+        errors: errors,
+        ns: ns,
+        xmlInputFactory: xmlInputFactory)
   }
 
 }

--- a/core/src/main/groovy/com/predic8/schema/Include.groovy
+++ b/core/src/main/groovy/com/predic8/schema/Include.groovy
@@ -24,9 +24,9 @@ import javax.xml.namespace.QName as JQName
 import static com.predic8.soamodel.Consts.SCHEMA_NS
 
 class Include extends SchemaComponent {
-  
+
   private static final Logger log = LoggerFactory.getLogger(Include.class)
-  
+
   String schemaLocation
 
    protected parseAttributes(token, ctx){
@@ -39,9 +39,13 @@ class Include extends SchemaComponent {
   private parseIncludedSchema(ctx){
     def resource = schema.resourceResolver.resolve(this, schema.baseDir)
 
-    def inputFactory = XMLInputFactory.newInstance()
-    inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
-    inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+    def inputFactory = ctx.xmlInputFactory
+    if (inputFactory == null) {
+      inputFactory = XMLInputFactory.newInstance()
+      inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
+      inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+    }
+
     def incToken = inputFactory.createXMLStreamReader(resource)
     while(incToken.hasNext()) {
       if(incToken.startElement) {
@@ -54,7 +58,9 @@ class Include extends SchemaComponent {
     def origBaseDir = schema.baseDir
     schema.baseDir = HTTPUtil.updateBaseDir(schemaLocation , schema.baseDir)
     log.debug("includedSchema.baseDir ${schema.baseDir}")
+    ctx.ns.push(schema)
     schema.parse(incToken, ctx.createNewSubContext([targetNamespace: schema.targetNamespace]))
+    ctx.ns.pop(schema)
     schema.baseDir = origBaseDir
   }
 
@@ -65,5 +71,5 @@ class Include extends SchemaComponent {
   String toString(){
     "schemaLocation=$schemaLocation"
   }
-  
+
 }

--- a/core/src/main/groovy/com/predic8/schema/SchemaParserContext.groovy
+++ b/core/src/main/groovy/com/predic8/schema/SchemaParserContext.groovy
@@ -24,7 +24,9 @@ class SchemaParserContext extends AbstractParserContext {
         input: args?.input,
         targetNamespace: args?.targetNamespace,
         importedSchemaCache: importedSchemaCache,
-        errors: errors)
+        errors: errors,
+        ns: ns,
+        xmlInputFactory: xmlInputFactory)
   }
 
 

--- a/core/src/main/groovy/com/predic8/soamodel/AbstractParser.groovy
+++ b/core/src/main/groovy/com/predic8/soamodel/AbstractParser.groovy
@@ -27,7 +27,7 @@ abstract class AbstractParser{
 
 	def resourceResolver = new ExternalResolver()
 
-	
+
 		protected parse(AbstractParserContext ctx) {
 		updatectx(ctx)
 		log.debug("AbstractParser: ctx.newBaseDir: ${ctx.newBaseDir} , ctx.input: " + ctx.input)
@@ -44,13 +44,16 @@ abstract class AbstractParser{
 	}
 
 	private getResourceToken(ctx) {
-		getToken(resourceResolver.resolve(ctx.input, ctx.baseDir))
+		getToken(resourceResolver.resolve(ctx.input, ctx.baseDir), ctx)
 	}
 
-	private getToken(res) {
-		def inputFactory = XMLInputFactory.newInstance()
-		inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
-		inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+	private getToken(res, ctx) {
+		def inputFactory = ctx.xmlInputFactory
+		if (inputFactory == null) {
+			inputFactory = XMLInputFactory.newInstance()
+			inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
+			inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+		}
 		inputFactory.createXMLStreamReader(res)
 	}
 }

--- a/core/src/main/groovy/com/predic8/soamodel/AbstractParserContext.groovy
+++ b/core/src/main/groovy/com/predic8/soamodel/AbstractParserContext.groovy
@@ -17,7 +17,10 @@ package com.predic8.soamodel
 import com.predic8.ParserImportedSchemaCache
 import com.predic8.schema.Import
 import com.predic8.schema.Schema
+import com.predic8.wsdl.ns.NSContext
 import com.predic8.xml.util.ResourceResolver
+
+import javax.xml.stream.XMLInputFactory
 
 abstract class AbstractParserContext {
 
@@ -31,6 +34,10 @@ abstract class AbstractParserContext {
   def wsiResults = []
 	def errors = []
 	def validated = []
+
+  def ns = new NSContext()
+
+  XMLInputFactory xmlInputFactory = null
 
   //TODO ITHENA what with Included schema's? (com.predic8.schema.Include & com.predic8.wadl.Include)
   ParserImportedSchemaCache importedSchemaCache = new ParserImportedSchemaCache()

--- a/core/src/main/groovy/com/predic8/wadl/WADLParserContext.groovy
+++ b/core/src/main/groovy/com/predic8/wadl/WADLParserContext.groovy
@@ -23,7 +23,9 @@ class WADLParserContext extends AbstractParserContext{
         input: args?.input,
         targetNamespace: args?.targetNamespace,
         importedSchemaCache: importedSchemaCache,
-        errors: errors)
+        errors: errors,
+        ns: ns,
+        xmlInputFactory: xmlInputFactory)
   }
 
 }

--- a/core/src/main/groovy/com/predic8/wsdl/WSDLParserContext.groovy
+++ b/core/src/main/groovy/com/predic8/wsdl/WSDLParserContext.groovy
@@ -17,10 +17,10 @@ package com.predic8.wsdl
 import com.predic8.soamodel.AbstractParserContext;
 
 class WSDLParserContext extends AbstractParserContext{
-	
+
 	Map<String, String> wsdlImports = [:]
 	Map<String, Definitions> importedWSDLs = [:]
-	
+
 	List<WSDLElement>	wsdlElementOrder = []
 
   def createNewSubContext(args) {
@@ -28,7 +28,9 @@ class WSDLParserContext extends AbstractParserContext{
         input: args?.input,
         targetNamespace: args?.targetNamespace,
         importedSchemaCache: importedSchemaCache,
-        errors: errors)
+        errors: errors,
+        ns: ns,
+        xmlInputFactory: xmlInputFactory)
   }
 
 }

--- a/core/src/main/java/com/predic8/wsdl/ns/NSContext.java
+++ b/core/src/main/java/com/predic8/wsdl/ns/NSContext.java
@@ -1,0 +1,128 @@
+package com.predic8.wsdl.ns;
+
+import com.predic8.schema.Schema;
+import com.predic8.soamodel.XMLElement;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NSContext {
+
+	private static final Pattern SEED = Pattern.compile("[0-9]+$");
+
+	private Map<XMLElement, Stack<Map<String, String>>> stack = new HashMap<>();
+
+	/**
+	 * Verifies element namespaces and returns next possible entry to avoid override
+	 */
+	public Map.Entry<String, String> namespace(XMLElement element, String prefix, String namespace) {
+		Map<String, String> refs = reference(element, true, false);
+		if (refs != null) {
+			Map<String, String> namespaces = element.namespaces();
+			String ns = namespaces.get(prefix);
+			if (ns != null && !Objects.equals(ns, namespace)) {
+				String next = next(namespaces.keySet(), prefix);
+				if (!next.equals(prefix)) {
+					refs.put(prefix, next);
+					prefix = next;
+				}
+			}
+		}
+		return new AbstractMap.SimpleEntry<>(prefix, namespace);
+	}
+
+	/**
+	 * Returns new prefix value from stack of current loading session
+	 */
+	public String prefix(XMLElement element, String prefix) {
+		return reference(element).getOrDefault(prefix, prefix);
+	}
+
+	private Map<String, String> reference(XMLElement element) {
+		return reference(element, false, true);
+	}
+
+	private Map<String, String> reference(XMLElement element, boolean returnNull, boolean useParents) {
+		Map<String, String> result = returnNull ? null : Collections.emptyMap();
+		if (stack.containsKey(element)) {
+			Stack<Map<String, String>> st = stack.get(element);
+			if (!st.isEmpty()) {
+				result = st.get(st.size() - 1);
+			}
+		} else if (element != null && useParents) {
+			result = reference(element.getParent(), returnNull, useParents);
+		}
+		return result;
+	}
+
+	/**
+	 * Pushes previous schema namespace references (or creates new if previous missed) in stack. Must be called BEFORE schema.parse
+	 */
+	public void push(Schema schema) {
+		stack.computeIfAbsent(
+			schema, (k) -> new Stack<>()
+		).push(new HashMap<>());
+	}
+
+	/**
+	 * Pops current schema namespace references from stack. Must be called AFTER schema.parse
+	 */
+	public void pop(Schema schema) {
+		if (stack.containsKey(schema)) {
+			stack.get(schema).pop();
+		}
+	}
+
+
+	private static String next(Collection<String> prefixes, String prefix) {
+		if (isEmpty(prefixes) || StringUtils.isEmpty(prefix)) {
+			return prefix;
+		}
+		Integer seed = seed(prefix);
+		String pfx = seed == null ? prefix : StringUtils.substringBeforeLast(prefix, String.valueOf(seed));
+		String searchPattern = String.format("^%s$", seed != null ? String.format("%s[0-9]*", pfx) : pfx);
+		boolean changed = false;
+		for (String p : prefixes) {
+			if (p == null) {
+				continue;
+			}
+			if (!p.matches(searchPattern)) {
+				continue;
+			}
+			Integer sd = seed(p);
+			if (sd == null) {
+				continue;
+			}
+			if (seed == null || sd >= seed) {
+				changed = true;
+				seed = sd;
+			}
+		}
+		if (seed == null) {
+			changed = true;
+			seed = -1;
+		}
+		if (changed) {
+			seed++;
+		}
+		return String.format("%s%d", pfx, seed);
+	}
+
+	private static Integer seed(String value) {
+		Matcher matcher = SEED.matcher(value);
+		return matcher.find() ? Integer.parseInt(matcher.group()) : null;
+	}
+
+	private static boolean isEmpty(Collection<?> collection) {
+		return collection == null || collection.size() == 0;
+	}
+}

--- a/core/src/test/groovy/com/predic8/wsdl/NSContextTest.groovy
+++ b/core/src/test/groovy/com/predic8/wsdl/NSContextTest.groovy
@@ -1,0 +1,36 @@
+package com.predic8.wsdl
+
+import com.predic8.wsdl.ns.NSContext
+import com.predic8.xml.util.ClasspathResolver
+
+class NSContextTest extends GroovyTestCase {
+
+  def parser = new WSDLParser(resourceResolver: new ClasspathResolver())
+
+  void testDisabled() {
+    NSContext.enable(false)
+    assert namespaces() == [
+      "ns0": "http://xmlns.oracle.com/adf/svc/types/",
+      // value of last processed namespace with "ns1" prefix
+      "ns1": "http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierContact/"
+    ]
+  }
+
+  void testEnabled() {
+    NSContext.enable(true)
+    assert namespaces() == [
+      "ns0": "http://xmlns.oracle.com/adf/svc/types/",
+      // has unique prefix for each processed namespace, that was defined with "ns1" prefix
+      "ns1": "http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/",
+      "ns2": "http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/",
+      "ns3": "http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierAddress/",
+      "ns4": "http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierContact/"
+    ]
+  }
+
+  // returns namespaces of specific schema, that has issues with overrode namespaces
+  def namespaces() {
+    def wsdl = parser.parse("supplier-service-v2/SupplierServiceV2.wsdl")
+    return wsdl.schemas[6].namespaces().findAll { it.key.startsWith("ns") }
+  }
+}

--- a/core/src/test/resources/supplier-service-v2/BC4JService.xsd
+++ b/core/src/test/resources/supplier-service-v2/BC4JService.xsd
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/adf/svc/types/"
+     sdoJava:package="oracle.jbo.common.service.types" xmlns:errors="http://xmlns.oracle.com/adf/svc/errors/"
+     xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java" xmlns:sdoXML="commonj.sdo/xml"
+     xmlns="http://xmlns.oracle.com/adf/svc/types/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/errors/" schemaLocation="ServiceException.xsd"/>
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:import namespace="commonj.sdo/xml" schemaLocation="sdoXML.xsd"/>
+    <xsd:element name="findCriteria" type="FindCriteria"/>
+    <xsd:complexType name="FindCriteria">
+        <xsd:sequence>
+            <xsd:element default="0" name="fetchStart" type="xsd:int"/>
+            <xsd:element default="-1" name="fetchSize" type="xsd:int"/>
+            <xsd:element minOccurs="0" name="filter" type="ViewCriteria"/>
+            <xsd:element minOccurs="0" name="sortOrder" type="SortOrder"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="findAttribute" type="xsd:string"/>
+            <xsd:element default="false" name="excludeAttribute" type="xsd:boolean"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="childFindCriteria" type="ChildFindCriteria"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ViewCriteria">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="conjunction" type="Conjunction"/>
+            <xsd:element maxOccurs="unbounded" name="group" type="ViewCriteriaRow"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="nested" type="ViewCriteria"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ViewCriteriaRow">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="conjunction" type="Conjunction"/>
+            <xsd:element default="false" name="upperCaseCompare" type="xsd:boolean"/>
+            <xsd:element maxOccurs="unbounded" name="item" type="ViewCriteriaItem"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ViewCriteriaItem">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="conjunction" type="Conjunction"/>
+            <xsd:element default="false" name="upperCaseCompare" type="xsd:boolean"/>
+            <xsd:element name="attribute" type="xsd:string"/>
+            <xsd:element name="operator" type="xsd:string"/>
+            <xsd:choice>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="value" type="xsd:anySimpleType"/>
+                <xsd:element name="nested" type="ViewCriteria"/>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="Conjunction" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="And"/>
+            <xsd:enumeration value="Or"/>
+            <xsd:enumeration value="Not"/>
+            <xsd:enumeration value="AndNot"/>
+            <xsd:enumeration value="OrNot"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:complexType name="SortOrder">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" name="sortAttribute" type="SortAttribute"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SortAttribute">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string"/>
+            <xsd:element default="false" name="descending" type="xsd:boolean"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ChildFindCriteria">
+        <xsd:complexContent>
+            <xsd:extension base="FindCriteria">
+                <xsd:sequence>
+                    <xsd:element name="childAttrName" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:simpleType name="ChangeOperation" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Create"/>
+            <xsd:enumeration value="Update"/>
+            <xsd:enumeration value="Merge"/>
+            <xsd:enumeration value="Delete"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:element name="findControl" type="FindControl"/>
+    <xsd:complexType name="FindControl">
+        <xsd:sequence>
+            <xsd:element default="false" name="retrieveAllTranslations" type="xsd:boolean"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="processControl" type="ProcessControl"/>
+    <xsd:complexType name="ProcessControl">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="returnMode" type="ReturnMode"/>
+            <xsd:element minOccurs="0" name="exceptionReturnMode" type="ReturnMode"/>
+            <xsd:element default="false" name="partialFailureAllowed" type="xsd:boolean"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="ReturnMode" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Full"/>
+            <xsd:enumeration value="Key"/>
+            <xsd:enumeration value="None"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="base64Binary-DataHandler" sdoJava:instanceClass="javax.activation.DataHandler">
+        <xsd:restriction base="xsd:base64Binary"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="dateTime-Timestamp" sdoJava:instanceClass="java.sql.Timestamp">
+        <xsd:restriction base="xsd:dateTime"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="time-Time" sdoJava:instanceClass="java.sql.Time">
+        <xsd:restriction base="xsd:time"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="date-Date" sdoJava:instanceClass="java.sql.Date">
+        <xsd:restriction base="xsd:date"/>
+    </xsd:simpleType>
+    <xsd:complexType name="AmountType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:decimal">
+                <xsd:attribute name="currencyCode" type="xsd:normalizedString" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="MeasureType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:decimal">
+                <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:complexType name="MethodResult">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Message" type="errors:ServiceMessage"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="BigDecimalResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:decimal"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="BigIntegerResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:integer"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="BooleanResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:boolean"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ByteResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:byte"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="BytesResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:hexBinary"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="TimestampResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:dateTime" sdoXML:dataType="dateTime-Timestamp"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="TimeResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:time" sdoXML:dataType="time-Time"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DateResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:date" sdoXML:dataType="date-Date"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DoubleResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:double"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="FloatResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:float"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="IntegerResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:int"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="LongResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:long"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ShortResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:short"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="StringResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DataHandlerResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="base64Binary-DataHandler"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DataObjectResult">
+        <xsd:complexContent>
+            <xsd:extension base="MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="xsd:anyType" sdoXML:dataType="sdo:DataObject"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ObjAttrHints">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="objHint" type="CtrlHint"/>
+            <xsd:element maxOccurs="unbounded" name="attrHints" type="AttrCtrlHints"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="AttrCtrlHints">
+        <xsd:sequence>
+            <xsd:element name="attrName" type="xsd:string"/>
+            <xsd:element maxOccurs="unbounded" name="ctrlHint" type="CtrlHint"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CtrlHint">
+        <xsd:sequence>
+            <xsd:element name="key" type="xsd:string"/>
+            <xsd:element name="value" type="xsd:anySimpleType"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ServiceViewInfo">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string"/>
+            <xsd:element name="typeName" type="xsd:string"/>
+            <xsd:element default="false" minOccurs="0" name="canCreate" type="xsd:boolean"/>
+            <xsd:element default="false" minOccurs="0" name="canUpdate" type="xsd:boolean"/>
+            <xsd:element default="false" minOccurs="0" name="canMerge" type="xsd:boolean"/>
+            <xsd:element default="false" minOccurs="0" name="canDelete" type="xsd:boolean"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/Diot.xsd
+++ b/core/src/test/resources/supplier-service-v2/Diot.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="PozSupplierIntDFF.xsd"/>
+    <xsd:complexType name="Diot">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="PozSupplierIntDFF">
+                <xsd:sequence>
+                    <xsd:element minOccurs="0" name="tipoDeTercero" nillable="true" type="xsd:string"/>
+                    <xsd:element minOccurs="0" name="paIsDeResidencia" nillable="true" type="xsd:string"/>
+                    <xsd:element minOccurs="0" name="nacionalidad" nillable="true" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="diot" type="Diot"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/PozSupAddressesIntDFF.xsd
+++ b/core/src/test/resources/supplier-service-v2/PozSupAddressesIntDFF.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierAddress/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierAddress/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:complexType name="PozSupAddressesIntDFF">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>AddressInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="AddressInterfaceId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context_DisplayValue" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="_FLEX_NumOfSegments" nillable="true" type="xsd:int"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="pozSupAddressesIntDFF" type="PozSupAddressesIntDFF"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/PozSupContactsIntDFF.xsd
+++ b/core/src/test/resources/supplier-service-v2/PozSupContactsIntDFF.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierContact/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierContact/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:complexType name="PozSupContactsIntDFF">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>ContactInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="ContactInterfaceId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context_DisplayValue" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="_FLEX_NumOfSegments" nillable="true" type="xsd:int"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="pozSupContactsIntDFF" type="PozSupContactsIntDFF"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/PozSupplierIntDFF.xsd
+++ b/core/src/test/resources/supplier-service-v2/PozSupplierIntDFF.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="Diot.xsd"
+         xml:id="Diot-xsd"/>
+    <xsd:include schemaLocation="ProveedorEmpleado.xsd"
+         xml:id="ProveedorEmpleado-xsd"/>
+    <xsd:complexType name="PozSupplierIntDFF">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="VendorInterfaceId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context_DisplayValue" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="_FLEX_NumOfSegments" nillable="true" type="xsd:int"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="pozSupplierIntDFF" type="PozSupplierIntDFF"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/PozSupplierSitesIntDFF.xsd
+++ b/core/src/test/resources/supplier-service-v2/PozSupplierSitesIntDFF.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="TipoDeProveedor.xsd"
+         xml:id="TipoDeProveedor-xsd"/>
+    <xsd:complexType name="PozSupplierSitesIntDFF">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorSiteInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="VendorSiteInterfaceId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="__FLEX_Context_DisplayValue" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="_FLEX_NumOfSegments" nillable="true" type="xsd:int"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="pozSupplierSitesIntDFF" type="PozSupplierSitesIntDFF"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/ProveedorEmpleado.xsd
+++ b/core/src/test/resources/supplier-service-v2/ProveedorEmpleado.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="PozSupplierIntDFF.xsd"/>
+    <xsd:complexType name="ProveedorEmpleado">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="PozSupplierIntDFF">
+                <xsd:sequence>
+                    <xsd:element minOccurs="0" name="proveedorEmpleado" nillable="true" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="proveedorEmpleado" type="ProveedorEmpleado"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/ServiceException.wsdl
+++ b/core/src/test/resources/supplier-service-v2/ServiceException.wsdl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definitions
+    
+     targetNamespace="http://xmlns.oracle.com/adf/svc/errors/"
+     xmlns="http://schemas.xmlsoap.org/wsdl/"
+     xmlns:tns="http://xmlns.oracle.com/adf/svc/errors/"
+    >
+    <types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema">
+            <import namespace="http://xmlns.oracle.com/adf/svc/errors/" schemaLocation="ServiceException.xsd"/>
+        </schema>
+    </types>
+    <message name="ServiceException">
+        <part name="ServiceErrorMessage" element="tns:ServiceErrorMessage"/>
+    </message>
+</definitions>

--- a/core/src/test/resources/supplier-service-v2/ServiceException.xsd
+++ b/core/src/test/resources/supplier-service-v2/ServiceException.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/adf/svc/errors/"
+     sdoJava:package="oracle.jbo.service.errors" xmlns:sdoJava="commonj.sdo/java" xmlns:tns="http://xmlns.oracle.com/adf/svc/errors/"
+     xmlns="http://www.w3.org/2001/XMLSchema">
+    <import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <element name="ServiceErrorMessage" type="tns:ServiceErrorMessage"/>
+    <complexType name="ServiceMessage">
+        <sequence>
+            <element maxOccurs="1" minOccurs="0" name="code" type="string"/>
+            <element maxOccurs="1" minOccurs="0" name="message" type="string"/>
+            <element maxOccurs="1" minOccurs="0" name="severity" type="string"/>
+            <element maxOccurs="unbounded" minOccurs="0" name="detail" type="tns:ServiceMessage"/>
+        </sequence>
+    </complexType>
+    <complexType name="ServiceErrorMessage">
+        <complexContent>
+            <extension base="tns:ServiceMessage">
+                <sequence>
+                    <element maxOccurs="1" minOccurs="0" name="sdoObject" type="anyType"/>
+                    <element maxOccurs="1" minOccurs="0" name="exceptionClassName" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="ServiceAttrValErrorMessage">
+        <complexContent>
+            <extension base="tns:ServiceErrorMessage">
+                <sequence>
+                    <element maxOccurs="1" minOccurs="0" name="attributeName" type="string"/>
+                    <element maxOccurs="1" minOccurs="0" name="attributeValue" type="anySimpleType"/>
+                    <element maxOccurs="1" minOccurs="0" name="objectName" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="ServiceRowValErrorMessage">
+        <complexContent>
+            <extension base="tns:ServiceErrorMessage">
+                <sequence>
+                    <element maxOccurs="1" minOccurs="0" name="objectName" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="ServiceDMLErrorMessage">
+        <complexContent>
+            <extension base="tns:ServiceErrorMessage">
+                <sequence>
+                    <element maxOccurs="1" minOccurs="0" name="operation" type="string"/>
+                    <element maxOccurs="1" minOccurs="0" name="statement" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/core/src/test/resources/supplier-service-v2/Supplier.xsd
+++ b/core/src/test/resources/supplier-service-v2/Supplier.xsd
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:ns1="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+     xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java" xmlns:sdoXML="commonj.sdo/xml"
+     xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier</name>
+            <description>Supplier and child entities Information which are either going
+                to be created or updated</description>
+            <oer:category name="lba">
+                <value>PrcTop-Procurement</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                    PrcPozSuppliers-Suppliers</value>
+            </oer:category>
+            <oer:attributes>
+                <oer:attribute description="Supplier unique identifier. The value can be obtained from the VENDOR_ID column in the POZ_SUPPLIERS table."
+                     name="SupplierId"/>
+                <oer:attribute description="The name of the supplier." name="Supplier"/>
+                <oer:attribute description="New value provided for supplier name. Valid only for Update operation."
+                     name="SupplierNew"/>
+                <oer:attribute description="Supplier number. If you plan to use automatic supplier numbering then no value needs to be provided here."
+                     name="SupplierNumber"/>
+                <oer:attribute description="The alternate name of the supplier." name="AlternateName"/>
+                <oer:attribute description="The tax organization type for the supplier. Values include, Corporation, Foreign Corporation, Individual etc."
+                     name="TaxOrganizationType"/>
+                <oer:attribute description="Supplier type." name="SupplierType"/>
+                <oer:attribute description="Date on which the supplier ceases to be active." name="InactiveDate"/>
+                <oer:attribute description="Business relationship for the supplier. Valid values are Prospective and Spend Authorized."
+                     name="BusinessRelationship"/>
+                <oer:attribute description="Indicates whether the business classification is applicable for the supplier."
+                     name="BusinessClassificationNotApplicableFlag"/>
+                <oer:attribute description="Id of the parent supplier that is associated with the current supplier record."
+                     name="ParentSupplierId"/>
+                <oer:attribute description="Parent Supplier name that is associated with the current supplier record."
+                     name="ParentSupplierName"/>
+                <oer:attribute description="Additional name to identify the supplier for the buying organization."
+                     name="Alias"/>
+                <oer:attribute description="Additional name to identify the supplier for the buying organization."
+                     name="DUNSNumber"/>
+                <oer:attribute description="Indicates whether the supplier is identified as a one-time supplier."
+                     name="OneTimeSupplierFlag"/>
+                <oer:attribute description="An identifier used by the supplier to identify the buying organization."
+                     name="CustomerNumber"/>
+                <oer:attribute description="A code that uniquely identifies the supplier organization used in several countries to classify organizations based on industry areas. In the US, it is typically represented by a 4 digit code used primarily in government agencies."
+                     name="StandardIndustryClassification"/>
+                <oer:attribute description="A unique identifier typically representing suppilers that are individuals. The national identification number is used in several countries to track individuals for the purposes of work, taxation and government benefits."
+                     name="NationalInsuranceNumber"/>
+                <oer:attribute description="Website of the supplier." name="CorporateWebsite"/>
+                <oer:attribute description="Supplier profile information indicating the year the supplier was established."
+                     name="YearEstablished"/>
+                <oer:attribute description="Supplier profile information indicating the year the supplier was incorporated."
+                     name="YearIncorporated"/>
+                <oer:attribute description="Supplier profile information capturing the title of the Chief Executive Officer of the supplier organization."
+                     name="ChiefExecutiveTitle"/>
+                <oer:attribute description="Supplier profile information capturing the name of the Chief Executive Officer of the supplier organization."
+                     name="ChiefExecutiveName"/>
+                <oer:attribute description="Supplier profile information capturing the title of the principal officer of the supplier organization."
+                     name="PrincipalTitle"/>
+                <oer:attribute description="Supplier profile information capturing the name of the principal officer of the supplier organization."
+                     name="PrincipalName"/>
+                <oer:attribute description="Month in which the fiscal year ends in the supplier organization."
+                     name="FiscalYearEndMonth"/>
+                <oer:attribute description="The supplier organization&amp;apos;s potential revenue for the current fiscal year."
+                     name="CurrentFiscalYearPotentialRevenue"/>
+                <oer:attribute description="Organization&apos;s default currency code." name="Currency"/>
+                <oer:attribute description="Country of the supplier organization responsible for taxation."
+                     name="TaxPayerCountry"/>
+                <oer:attribute description="Unique tax identifier of the supplier organization." name="TaxpayerId"/>
+                <oer:attribute description="Indicates whether the supplier is reportable under federal taxation laws. Valid values are TRUE or FALSE."
+                     name="FederalReportableFlag"/>
+                <oer:attribute description="Represents the 1099 Type applicable to the supplier that is federal reportable and used for tax reporting."
+                     name="FederalIncomeTaxType"/>
+                <oer:attribute description="Indicates whether the supplier is reportable under state taxation laws. Valid values are TRUE or FALSE."
+                     name="StateReportableFlag"/>
+                <oer:attribute description="Name of the organization as displayed for 1099 reporting purposes."
+                     name="TaxReportingName"/>
+                <oer:attribute description="Name identifier for the supplier organization." name="NameControl"/>
+                <oer:attribute description="Indicates the date on which the 1099 Tax details were last received from the supplier."
+                     name="TaxVerificationDate"/>
+                <oer:attribute description="Indicates whether the withholding tax is applicable to the supplier."
+                     name="UseWithholdingTaxFlag"/>
+                <oer:attribute description="Unique withholding tax group identifier on a supplier record."
+                     name="WithholdingTaxGroupId"/>
+                <oer:attribute description="Identifies the withholding tax group assigned to the supplier record."
+                     name="WithholdingTaxGroup"/>
+                <oer:attribute description="A unique identifier of the supplier record from an external system. This is used to carry a reference from the source system for the supplier."
+                     name="ExternalSystemId"/>
+                <oer:attribute description="Original system reference details of the supplier record as stored in an external system. This is used to carry reference information from the source system for the supplier."
+                     name="ExternalSystem"/>
+                <oer:attribute description="Entity that captures the details of diversity classifications to which the supplier belongs."
+                     name="SupplierBusinessClassifications"/>
+                <oer:attribute description="Entity that captures the business relationship between a procurement business unit in a buying organization and the supplier. The site captures business terms and conditions as negotiated by the business unit with the supplier."
+                     name="SupplierSites"/>
+                <oer:attribute description="Entity that captures the products and services categories that the supplier agrees to supply to the buying organization."
+                     name="SupplierProductsandServicesCategory"/>
+                <oer:attribute description="Entity that captures the physical location of business that the supplier uses to conduct procurement activity."
+                     name="SupplierAddresses"/>
+                <oer:attribute description="An object that enables customers to extend the supplier information."
+                     name="SupplierFlexField"/>
+                <oer:attribute description="Entity that captures details of individuals that belong to the supplier organization who work with the buying organization."
+                     name="SupplierContacts"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplier/"
+         schemaLocation="PozSupplierIntDFF.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:import namespace="commonj.sdo/xml" schemaLocation="sdoXML.xsd"/>
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:include schemaLocation="SupplierBusinessClassifications.xsd"/>
+    <xsd:include schemaLocation="SupplierSites.xsd"/>
+    <xsd:include schemaLocation="SupplierProductsandServicesCategory.xsd"/>
+    <xsd:include schemaLocation="SupplierAddresses.xsd"/>
+    <xsd:include schemaLocation="SupplierContacts.xsd"/>
+    <xsd:complexType name="Supplier">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="SupplierId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="Supplier" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SupplierNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SupplierNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AlternateName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="TaxOrganizationType" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SupplierType" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InactiveDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="BusinessRelationship" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BusinessClassificationNotApplicableFlag" nillable="true"
+                 type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="ParentSupplierId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ParentSupplierName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Alias" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="DUNSNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="OneTimeSupplierFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="CustomerNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="StandardIndustryClassification" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="NationalInsuranceNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CorporateWebsite" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="YearEstablished" nillable="true" type="xsd:int"/>
+            <xsd:element minOccurs="0" name="YearIncorporated" nillable="true" type="xsd:int"/>
+            <xsd:element minOccurs="0" name="ChiefExecutiveTitle" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ChiefExecutiveName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PrincipalTitle" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PrincipalName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FiscalYearEndMonth" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CurrentFiscalYearPotentialRevenue" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="Currency" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="TaxPayerCountry" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="TaxpayerId" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FederalReportableFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="FederalIncomeTaxType" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="StateReportableFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="TaxReportingName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="NameControl" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="TaxVerificationDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="UseWithholdingTaxFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="WithholdingTaxGroupId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="WithholdingTaxGroup" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ExternalSystemId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ExternalSystem" nillable="true" type="xsd:string"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierBusinessClassifications"
+                 type="SupplierBusinessClassifications"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierSites" type="SupplierSites"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierProductsandServicesCategory"
+                 type="SupplierProductsandServicesCategory"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierAddresses" type="SupplierAddresses"/>
+            <xsd:element minOccurs="0" name="SupplierFlexField" type="ns1:PozSupplierIntDFF" sdoXML:dataType="sdo:DataObject"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierContacts" type="SupplierContacts"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="Supplier"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="supplierResult" type="SupplierResult"/>
+    <xsd:element name="supplier" type="Supplier"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierAddresses.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierAddresses.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:ns1="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierAddress/"
+     xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java" xmlns:sdoXML="commonj.sdo/xml"
+     xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Address</name>
+            <description>Entity that captures the physical location of business that the
+                supplier uses to conduct procurement activity.</description>
+            <oer:category name="lba">
+                <value>PrcTop-Procurement</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                    PrcPozSuppliers-Suppliers</value>
+            </oer:category>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Supplier address record unique identifier." name="AddressId"/>
+                <oer:attribute description="Name of the supplier address." name="AddressName"/>
+                <oer:attribute description="Updated value for supplier address name." name="AddressNameNew"/>
+                <oer:attribute description="Country to which the supplier address belongs." name="Country"/>
+                <oer:attribute description="Address Line 1 of the supplier address record." name="AddressLine1"/>
+                <oer:attribute description="Address Line 2 of the supplier address record." name="AddressLine2"/>
+                <oer:attribute description="Address Line 3 of the supplier address record." name="AddressLine3"/>
+                <oer:attribute description="Address Line 4 of the supplier address record." name="AddressLine4"/>
+                <oer:attribute description="Phonetic or Kana representation of the Kanji Address lines. (used in Japan)."
+                     name="AddressLinePhonetic"/>
+                <oer:attribute description="Additional address element to support flexible address format."
+                     name="AddressElementAttribute1"/>
+                <oer:attribute description="Additional address element to support flexible address format."
+                     name="AddressElementAttribute2"/>
+                <oer:attribute description="Additional address element to support flexible address format."
+                     name="AddressElementAttribute3"/>
+                <oer:attribute description="Additional address element to support flexible address format."
+                     name="AddressElementAttribute4"/>
+                <oer:attribute description="Additional address element to support flexible address format."
+                     name="AddressElementAttribute5"/>
+                <oer:attribute description="Specific building name or number at a given address."
+                     name="Building"/>
+                <oer:attribute description="Specific floor number at a given address or in a particular building when building number is provided."
+                     name="FloorNumber"/>
+                <oer:attribute description="City of supplier address." name="City"/>
+                <oer:attribute description="State of supplier address." name="State"/>
+                <oer:attribute description="Province of supplier address." name="Province"/>
+                <oer:attribute description="County of supplier address." name="County"/>
+                <oer:attribute description="Postal Code to which the supplier address belongs." name="PostalCode"/>
+                <oer:attribute description="Four digit extension to postal code." name="PostalPlus4Code"/>
+                <oer:attribute description="Addressee information." name="Addressee"/>
+                <oer:attribute description="Global location number that uniquely identifies each location in a trading partners enterprise."
+                     name="GlobalLocationNumber"/>
+                <oer:attribute description="Operating language of the supplier address. The value provided here is the Language Code."
+                     name="AddressLanguage"/>
+                <oer:attribute description="Date on which the supplier address becomes inactive."
+                     name="InactiveDate"/>
+                <oer:attribute description="Country code for phone." name="PhoneCountryCode"/>
+                <oer:attribute description="Area code for phone." name="PhoneAreaCode"/>
+                <oer:attribute description="Supplier phone number." name="Phone"/>
+                <oer:attribute description="Extension number of the supplier phone." name="PhoneExtension"/>
+                <oer:attribute description="Country code for fax." name="FaxCountryCode"/>
+                <oer:attribute description="Area code for fax." name="FaxAreaCode"/>
+                <oer:attribute description="Supplier fax number." name="Fax"/>
+                <oer:attribute description="E-Mail address associated with the supplier address."
+                     name="EmailAddress"/>
+                <oer:attribute description="Indicates whether the supplier address can be used for ordering."
+                     name="OrderingPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier address can be used for payment."
+                     name="RemitToPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier address can be used for RFQ or Bidding."
+                     name="RFQOrBiddingPurposeFlag"/>
+                <oer:attribute description="An object that enables customers to extend the supplier addresses information."
+                     name="SupplierAddressesFlexField"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierAddress/"
+         schemaLocation="PozSupAddressesIntDFF.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:import namespace="commonj.sdo/xml" schemaLocation="sdoXML.xsd"/>
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:complexType name="SupplierAddressesResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierAddresses"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierAddresses">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>AddressInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="AddressName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressNameNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Country" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressLine1" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressLine2" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressLine3" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressLine4" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressLinePhonetic" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressElementAttribute1" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressElementAttribute2" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressElementAttribute3" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressElementAttribute4" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressElementAttribute5" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Building" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FloorNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="City" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="State" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Province" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="County" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PostalCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PostalPlus4Code" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Addressee" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="GlobalLocationNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressLanguage" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InactiveDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="PhoneCountryCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PhoneAreaCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Phone" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PhoneExtension" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FaxCountryCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FaxAreaCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Fax" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="EmailAddress" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="OrderingPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="RemitToPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="RFQOrBiddingPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="SupplierAddressesFlexField" type="ns1:PozSupAddressesIntDFF"
+                 sdoXML:dataType="sdo:DataObject"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="supplierAddressesResult" type="SupplierAddressesResult"/>
+    <xsd:element name="supplierAddresses" type="SupplierAddresses"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierBusinessClassifications.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierBusinessClassifications.xsd
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:sdoJava="commonj.sdo/java" xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Business Classification</name>
+            <description>Entity that captures the details of diversity classifications to
+                which the supplier belongs.</description>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Supplier business classification record unique identifier."
+                     name="BusinessClassificationId"/>
+                <oer:attribute description="Supplier business classification code." name="BusinessClassification"/>
+                <oer:attribute description="Updated value for business classification." name="BusinessClassificationNew"/>
+                <oer:attribute description="Subclassification for Minority Owned business classification."
+                     name="SubClassification"/>
+                <oer:attribute description="Updated value for sub classification applicable when business classification is Minority Owned."
+                     name="SubClassificationNew"/>
+                <oer:attribute description="Certifying agency unique identifier for a business classification."
+                     name="CertifyingAgencyId"/>
+                <oer:attribute description="Updated value for certifying agency on the business classification record."
+                     name="CertifyingAgencyIdNew"/>
+                <oer:attribute description="Name of the certifying agency associated with a business classification."
+                     name="CertifyingAgency"/>
+                <oer:attribute description="Updated value for certifying agency on the business classification record."
+                     name="CertifyingAgencyNew"/>
+                <oer:attribute description="Indicates whether a certifying agency should be created dynamically if one does not exist. This flag also allows the system to associate the agency with a business classification once created."
+                     name="CreateCertifyingAgencyFlag"/>
+                <oer:attribute description="The certificate number associated with the certifying agency on the business classification record."
+                     name="CertificateNumber"/>
+                <oer:attribute description="The updated certificate number associated with the certifying agency on the business classification record."
+                     name="CertificateNumberNew"/>
+                <oer:attribute description="The start date of the business classification." name="ClassificationStartDate"/>
+                <oer:attribute description="The end date of the business classification." name="ClassificationEndDate"/>
+                <oer:attribute description="Notes allows the user to capture any additional information regarding the classification."
+                     name="Notes"/>
+                <oer:attribute description="Indicates the date on which the business classificaiton record was last verified with the supplier."
+                     name="ConfirmedOnDate"/>
+                <oer:attribute description="Unique identifier of the supplier contact providing the business classification details."
+                     name="ProvidedByContactId"/>
+                <oer:attribute description="The first name of the supplier contact providing the business classification details."
+                     name="ProvidedByContactFirstName"/>
+                <oer:attribute description="The last name of the supplier contact providing the business classification details."
+                     name="ProvidedByContactLastName"/>
+                <oer:attribute description="The email address of the supplier contact providing the business classification details."
+                     name="ProvidedByContactEmail"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:complexType name="SupplierBusinessClassifications">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>ClassificationsInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BusinessClassificationId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="BusinessClassification" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BusinessClassificationNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SubClassification" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SubClassificationNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CertifyingAgencyId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="CertifyingAgencyIdNew" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="CertifyingAgency" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CertifyingAgencyNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CreateCertifyingAgencyFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="CertificateNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CertificateNumberNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ClassificationStartDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="ClassificationEndDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="Notes" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ConfirmedOnDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="ProvidedByContactId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ProvidedByContactFirstName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ProvidedByContactLastName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ProvidedByContactEmail" nillable="true" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierBusinessClassificationsResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierBusinessClassifications"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="supplierBusinessClassifications" type="SupplierBusinessClassifications"/>
+    <xsd:element name="supplierBusinessClassificationsResult" type="SupplierBusinessClassificationsResult"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierContactAddresses.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierContactAddresses.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:sdoJava="commonj.sdo/java" xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Contact Address</name>
+            <description>Entity that captures the details of addresses associated with
+                supplier contacts.</description>
+            <oer:category name="lba">
+                <value>PrcTop-Procurement</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                    PrcPozSuppliers-Suppliers</value>
+            </oer:category>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Unique identifier of a supplier address identified by the column PARTY_SIDE_ID in TCA."
+                     name="AddressId"/>
+                <oer:attribute description="Name of the supplier address." name="AddressName"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:complexType name="SupplierContactAddresses">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>ContactAddressInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="AddressName" nillable="true" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierContactAddressesResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierContactAddresses"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="supplierContactAddressesResult" type="SupplierContactAddressesResult"/>
+    <xsd:element name="supplierContactAddresses" type="SupplierContactAddresses"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierContacts.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierContacts.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:ns1="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierContact/"
+     xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java" xmlns:sdoXML="commonj.sdo/xml"
+     xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Contact</name>
+            <description>Entity that captures details of individuals that belong to the
+                supplier organization who work with the buying organization.</description>
+            <oer:category name="lba">
+                <value>PrcTop-Procurement</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                    PrcPozSuppliers-Suppliers</value>
+            </oer:category>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Supplier contact record unique identifier." name="ContactId"/>
+                <oer:attribute description="Indicates the name prefix for a supplier contact." name="Salutation"/>
+                <oer:attribute description="First name of the supplier contact." name="FirstName"/>
+                <oer:attribute description="Updated first name of the supplier contact." name="FirstNameNew"/>
+                <oer:attribute description="Middle name of the supplier contact." name="MiddleName"/>
+                <oer:attribute description="Last name of the supplier contact." name="LastName"/>
+                <oer:attribute description="Updated last name of the supplier contact." name="LastNameNew"/>
+                <oer:attribute description="Job title of the supplier contact." name="JobTitle"/>
+                <oer:attribute description="Indicates whether the supplier contact is the primary administrative contact."
+                     name="AdministrativeContactFlag"/>
+                <oer:attribute description="E-Mail address of the supplier contact." name="EmailAddress"/>
+                <oer:attribute description="Updated value for email address of supplier contact."
+                     name="EmailAddressNew"/>
+                <oer:attribute description="Date on which the supplier contact becomes inactive."
+                     name="InactiveDate"/>
+                <oer:attribute description="Country code for phone." name="PhoneCountryCode"/>
+                <oer:attribute description="Area code for phone." name="PhoneAreaCode"/>
+                <oer:attribute description="Supplier phone number." name="Phone"/>
+                <oer:attribute description="Extension number of the supplier contact phone." name="PhoneExtension"/>
+                <oer:attribute description="Country code for supplier mobile contact." name="MobileCountryCode"/>
+                <oer:attribute description="Area code for supplier mobile contact." name="MobileAreaCode"/>
+                <oer:attribute description="Supplier mobile number." name="Mobile"/>
+                <oer:attribute description="Country code for fax." name="FaxCountryCode"/>
+                <oer:attribute description="Area code for fax." name="FaxAreaCode"/>
+                <oer:attribute description="Supplier fax number." name="Fax"/>
+                <oer:attribute description="An object that enables customers to extend the supplier contacts information."
+                     name="SupplierContactsFlexField"/>
+                <oer:attribute description="Entity that captures the details of addresses associated with supplier contacts."
+                     name="SupplierContactAddresses"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierContact/"
+         schemaLocation="PozSupContactsIntDFF.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:import namespace="commonj.sdo/xml" schemaLocation="sdoXML.xsd"/>
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:include schemaLocation="SupplierContactAddresses.xsd"/>
+    <xsd:complexType name="SupplierContactsResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierContacts"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierContacts">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>ContactInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ContactId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="Salutation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FirstName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FirstNameNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="MiddleName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="LastName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="LastNameNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="JobTitle" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AdministrativeContactFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="EmailAddress" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="EmailAddressNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InactiveDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="PhoneCountryCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PhoneAreaCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Phone" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PhoneExtension" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="MobileCountryCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="MobileAreaCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Mobile" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FaxCountryCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FaxAreaCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Fax" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SupplierContactsFlexField" type="ns1:PozSupContactsIntDFF"
+                 sdoXML:dataType="sdo:DataObject"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierContactAddresses" type="SupplierContactAddresses"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="supplierContactsResult" type="SupplierContactsResult"/>
+    <xsd:element name="supplierContacts" type="SupplierContacts"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierProductsandServicesCategory.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierProductsandServicesCategory.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:sdoJava="commonj.sdo/java" xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Products and Services Category</name>
+            <description>Entity that captures the products and services categories that
+                the supplier agrees to supply to the buying organization.</description>
+            <oer:category name="lba">
+                <value>PrcTop-Procurement</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                    PrcPozSuppliers-Suppliers</value>
+            </oer:category>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Products and services category identifier." name="ClassificationId"/>
+                <oer:attribute description="Identifies the products and services category type. Valid values are Browsing and Purchasing only."
+                     name="CategoryType"/>
+                <oer:attribute description="Products and services category identifier." name="CategoryId"/>
+                <oer:attribute description="Products and services category identifier." name="CategoryName"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:complexType name="SupplierProductsandServicesCategoryResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierProductsandServicesCategory"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierProductsandServicesCategory">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>CategoriesInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ClassificationId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="CategoryType" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CategoryId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="CategoryName" nillable="true" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="supplierProductsandServicesCategoryResult" type="SupplierProductsandServicesCategoryResult"/>
+    <xsd:element name="supplierProductsandServicesCategory" type="SupplierProductsandServicesCategory"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierService.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierService.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/types/"
+     xmlns:ns0="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/" xmlns:ns1="http://xmlns.oracle.com/adf/svc/errors/"
+     xmlns:tns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/types/"
+     xmlns="http://www.w3.org/2001/XMLSchema">
+    <import namespace="http://xmlns.oracle.com/adf/svc/errors/" schemaLocation="ServiceException.xsd"/>
+    <import namespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/" schemaLocation="Supplier.xsd"/>
+    <element name="updateSupplier">
+        <complexType>
+            <sequence>
+                <element name="supplierRow" type="ns0:Supplier"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="updateSupplierResponse">
+        <complexType>
+            <sequence>
+                <element name="result" type="string"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="createSupplier">
+        <complexType>
+            <sequence>
+                <element name="supplierRow" type="ns0:Supplier"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="createSupplierResponse">
+        <complexType>
+            <sequence>
+                <element name="result" type="string"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="createSupplierAsync">
+        <complexType>
+            <sequence>
+                <element name="supplierRow" type="ns0:Supplier"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="createSupplierAsyncResponse">
+        <complexType>
+            <sequence>
+                <element name="result" type="string"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="updateSupplierAsync">
+        <complexType>
+            <sequence>
+                <element name="supplierRow" type="ns0:Supplier"/>
+            </sequence>
+        </complexType>
+    </element>
+    <element name="updateSupplierAsyncResponse">
+        <complexType>
+            <sequence>
+                <element name="result" type="string"/>
+            </sequence>
+        </complexType>
+    </element>
+</schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierServiceV2.wsdl
+++ b/core/src/test/resources/supplier-service-v2/SupplierServiceV2.wsdl
@@ -1,0 +1,672 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<wsdl:definitions
+     name="SupplierService"
+     targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     xmlns:plnk="http://schemas.xmlsoap.org/ws/2003/05/partner-link/"
+     xmlns:errors="http://xmlns.oracle.com/adf/svc/errors/"
+     xmlns:orafault="http://xmlns.oracle.com/oracleas/schema/oracle-fault-11_0"
+     xmlns:tns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+     xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+     xmlns:types="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/types/"
+    >
+    <wsdl:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+        <name>Supplier</name>
+        <description>An inbound web service that supports allows both creation and update
+            of suppliers from external repositories into Oracle Fusion Suppliers.</description>
+        <docCategories>
+            <category>External</category>
+        </docCategories>
+        <oer:lifecycle>Active</oer:lifecycle>
+        <oer:compatibility>Supported - Backward Compatibility Assured</oer:compatibility>
+        <oer:category name="lba">
+            <value>PrcTop-Procurement</value>
+            <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+            <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                PrcPozSuppliers-Suppliers</value>
+        </oer:category>
+        <oer:operation name="updateSupplier">
+            <description>Update operation for Supplier and all its child objects.</description>
+            <oer:parameters>
+                <oer:parameter name="supplierRow" description="Supplier Information which is going to be updated."/>
+                <oer:return description="Result of the operation."/>
+            </oer:parameters>
+        </oer:operation>
+        <oer:operation name="createSupplier">
+            <description>Create operation for Supplier and all its child objects.</description>
+            <oer:parameters>
+                <oer:parameter name="supplierRow" description="Supplier Information which is going to be created."/>
+                <oer:return description="Result of the operation."/>
+            </oer:parameters>
+        </oer:operation>
+    </wsdl:documentation>
+    <plnk:partnerLinkType name="SupplierService">
+        <plnk:role name="SupplierServiceProvider">
+            <plnk:portType name="tns:SupplierService"/>
+        </plnk:role>
+        <plnk:role name="SupplierServiceRequestor">
+            <plnk:portType name="tns:SupplierServiceResponse"/>
+        </plnk:role>
+    </plnk:partnerLinkType>
+<wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SupplierServiceResponse_Fault_Policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"/><wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SupplierServiceResponse_Input_Policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+   <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <sp:Body/>
+      <sp:Header Namespace="http://www.w3.org/2005/08/addressing"/>
+      <sp:Header Namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing"/>
+      <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+   </sp:SignedParts>
+   <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <sp:Body/>
+      <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+   </sp:EncryptedParts>
+</wsp:Policy><wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SupplierServiceResponse_Output_Policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+   <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <sp:Body/>
+   </sp:SignedParts>
+   <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <sp:Body/>
+   </sp:EncryptedParts>
+</wsp:Policy><wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SupplierServiceSoapHttpPort_Fault_Policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+   <wsp:ExactlyOne>
+      <wsp:All/>
+      <wsp:All/>
+      <wsp:All/>
+      <wsp:All/>
+   </wsp:ExactlyOne>
+</wsp:Policy><wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SupplierServiceSoapHttpPort_Input_Policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+   <wsp:ExactlyOne>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Namespace="http://www.w3.org/2005/08/addressing"/>
+            <sp:Header Namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing"/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:EncryptedParts>
+      </wsp:All>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Namespace="http://www.w3.org/2005/08/addressing"/>
+            <sp:Header Namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing"/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:EncryptedParts>
+      </wsp:All>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Namespace="http://www.w3.org/2005/08/addressing"/>
+            <sp:Header Namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing"/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+            <sp:Header Name="SignatureConfirmation" Namespace="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd"/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:EncryptedParts>
+      </wsp:All>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Namespace="http://www.w3.org/2005/08/addressing"/>
+            <sp:Header Namespace="http://schemas.xmlsoap.org/ws/2004/08/addressing"/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+            <sp:Header Name="fmw-context" Namespace="http://xmlns.oracle.com/fmw/context/1.0"/>
+         </sp:EncryptedParts>
+      </wsp:All>
+   </wsp:ExactlyOne>
+</wsp:Policy><wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SupplierServiceSoapHttpPort_Output_Policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+   <wsp:ExactlyOne>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:EncryptedParts>
+      </wsp:All>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:EncryptedParts>
+      </wsp:All>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:EncryptedParts>
+      </wsp:All>
+      <wsp:All>
+         <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:SignedParts>
+         <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <sp:Body/>
+         </sp:EncryptedParts>
+      </wsp:All>
+   </wsp:ExactlyOne>
+</wsp:Policy><wsp:Policy xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="wsaddr_policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+   <wsaw:UsingAddressing xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"/>
+</wsp:Policy><wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="wss11_saml_or_username_token_with_message_protection_service_policy">
+   <wsp:ExactlyOne>
+      <wsp:All>
+         <sp:SymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:ProtectionToken>
+                  <wsp:Policy>
+                     <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never">
+                        <wsp:Policy>
+                           <sp:RequireThumbprintReference/>
+                           <sp:WssX509V3Token11/>
+                        </wsp:Policy>
+                     </sp:X509Token>
+                  </wsp:Policy>
+               </sp:ProtectionToken>
+               <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                     <sp:Basic128/>
+                  </wsp:Policy>
+               </sp:AlgorithmSuite>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+               <sp:IncludeTimestamp/>
+               <sp:ProtectTokens/>
+               <sp:OnlySignEntireHeadersAndBody/>
+            </wsp:Policy>
+         </sp:SymmetricBinding>
+         <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:SamlToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssSamlV11Token11/>
+                  </wsp:Policy>
+               </sp:SamlToken>
+            </wsp:Policy>
+         </sp:SignedSupportingTokens>
+         <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssX509V3Token11/>
+                  </wsp:Policy>
+               </sp:X509Token>
+            </wsp:Policy>
+         </sp:EndorsingSupportingTokens>
+         <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:RequireSignatureConfirmation/>
+               <sp:MustSupportRefEncryptedKey/>
+            </wsp:Policy>
+         </sp:Wss11>
+      </wsp:All>
+      <wsp:All>
+         <sp:SymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:ProtectionToken>
+                  <wsp:Policy>
+                     <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never">
+                        <wsp:Policy>
+                           <sp:RequireThumbprintReference/>
+                           <sp:WssX509V3Token11/>
+                        </wsp:Policy>
+                     </sp:X509Token>
+                  </wsp:Policy>
+               </sp:ProtectionToken>
+               <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                     <sp:Basic128Exn256/>
+                  </wsp:Policy>
+               </sp:AlgorithmSuite>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+               <sp:IncludeTimestamp/>
+               <sp:ProtectTokens/>
+               <sp:OnlySignEntireHeadersAndBody/>
+            </wsp:Policy>
+         </sp:SymmetricBinding>
+         <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:SamlToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssSamlV11Token11/>
+                  </wsp:Policy>
+               </sp:SamlToken>
+            </wsp:Policy>
+         </sp:SignedSupportingTokens>
+         <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssX509V3Token11/>
+                  </wsp:Policy>
+               </sp:X509Token>
+            </wsp:Policy>
+         </sp:EndorsingSupportingTokens>
+         <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:RequireSignatureConfirmation/>
+               <sp:MustSupportRefEncryptedKey/>
+            </wsp:Policy>
+         </sp:Wss11>
+      </wsp:All>
+      <wsp:All>
+         <sp:SymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:ProtectionToken>
+                  <wsp:Policy>
+                     <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never">
+                        <wsp:Policy>
+                           <sp:RequireThumbprintReference/>
+                           <sp:WssX509V3Token11/>
+                        </wsp:Policy>
+                     </sp:X509Token>
+                  </wsp:Policy>
+               </sp:ProtectionToken>
+               <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                     <sp:Basic128/>
+                  </wsp:Policy>
+               </sp:AlgorithmSuite>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+               <sp:IncludeTimestamp/>
+               <sp:OnlySignEntireHeadersAndBody/>
+            </wsp:Policy>
+         </sp:SymmetricBinding>
+         <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssUsernameToken10/>
+                  </wsp:Policy>
+               </sp:UsernameToken>
+            </wsp:Policy>
+         </sp:SignedSupportingTokens>
+         <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:RequireSignatureConfirmation/>
+               <sp:MustSupportRefEncryptedKey/>
+            </wsp:Policy>
+         </sp:Wss11>
+      </wsp:All>
+      <wsp:All>
+         <sp:SymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:ProtectionToken>
+                  <wsp:Policy>
+                     <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never">
+                        <wsp:Policy>
+                           <sp:RequireThumbprintReference/>
+                           <sp:WssX509V3Token11/>
+                        </wsp:Policy>
+                     </sp:X509Token>
+                  </wsp:Policy>
+               </sp:ProtectionToken>
+               <sp:AlgorithmSuite>
+                  <wsp:Policy>
+                     <sp:Basic128Exn256/>
+                  </wsp:Policy>
+               </sp:AlgorithmSuite>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+               <sp:IncludeTimestamp/>
+               <sp:OnlySignEntireHeadersAndBody/>
+            </wsp:Policy>
+         </sp:SymmetricBinding>
+         <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssUsernameToken10/>
+                  </wsp:Policy>
+               </sp:UsernameToken>
+            </wsp:Policy>
+         </sp:SignedSupportingTokens>
+         <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:RequireSignatureConfirmation/>
+               <sp:MustSupportRefEncryptedKey/>
+            </wsp:Policy>
+         </sp:Wss11>
+      </wsp:All>
+      <wsp:All>
+         <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:TransportToken>
+                  <wsp:Policy>
+                     <sp:HttpsToken RequireClientCertificate="false">
+                        <wsp:Policy/>
+                     </sp:HttpsToken>
+                  </wsp:Policy>
+               </sp:TransportToken>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+               <sp:IncludeTimestamp/>
+            </wsp:Policy>
+         </sp:TransportBinding>
+         <sp:SupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:SamlToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssSamlV11Token10/>
+                  </wsp:Policy>
+               </sp:SamlToken>
+            </wsp:Policy>
+         </sp:SupportingTokens>
+      </wsp:All>
+      <wsp:All>
+         <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:TransportToken>
+                  <wsp:Policy>
+                     <sp:HttpsToken RequireClientCertificate="false">
+                        <wsp:Policy/>
+                     </sp:HttpsToken>
+                  </wsp:Policy>
+               </sp:TransportToken>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+               <sp:IncludeTimestamp/>
+            </wsp:Policy>
+         </sp:TransportBinding>
+         <sp:SupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+                  <wsp:Policy>
+                     <sp:WssUsernameToken10/>
+                  </wsp:Policy>
+               </sp:UsernameToken>
+            </wsp:Policy>
+         </sp:SupportingTokens>
+      </wsp:All>
+      <wsp:All>
+         <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:TransportToken>
+                  <wsp:Policy>
+                     <sp:HttpsToken RequireClientCertificate="false">
+                        <wsp:Policy/>
+                     </sp:HttpsToken>
+                  </wsp:Policy>
+               </sp:TransportToken>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+            </wsp:Policy>
+         </sp:TransportBinding>
+      </wsp:All>
+      <wsp:All>
+         <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+            <wsp:Policy>
+               <sp:TransportToken>
+                  <wsp:Policy>
+                     <sp:HttpsToken RequireClientCertificate="false">
+                        <wsp:Policy>
+                           <osp:HttpJwtAuthentication xmlns:osp="http://schemas.oracle.com/ws/2012/01/wssecuritypolicy"/>
+                        </wsp:Policy>
+                     </sp:HttpsToken>
+                  </wsp:Policy>
+               </sp:TransportToken>
+               <sp:Layout>
+                  <wsp:Policy>
+                     <sp:Lax/>
+                  </wsp:Policy>
+               </sp:Layout>
+            </wsp:Policy>
+         </sp:TransportBinding>
+      </wsp:All>
+   </wsp:ExactlyOne>
+</wsp:Policy><wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="wss11_saml_token_with_message_protection_client_policy">
+   <sp:SymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <wsp:Policy>
+         <sp:ProtectionToken>
+            <wsp:Policy>
+               <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never">
+                  <wsp:Policy>
+                     <sp:RequireThumbprintReference/>
+                     <sp:WssX509V3Token11/>
+                  </wsp:Policy>
+               </sp:X509Token>
+            </wsp:Policy>
+         </sp:ProtectionToken>
+         <sp:AlgorithmSuite>
+            <wsp:Policy>
+               <sp:Basic128/>
+            </wsp:Policy>
+         </sp:AlgorithmSuite>
+         <sp:Layout>
+            <wsp:Policy>
+               <sp:Lax/>
+            </wsp:Policy>
+         </sp:Layout>
+         <sp:IncludeTimestamp/>
+         <sp:ProtectTokens/>
+         <sp:OnlySignEntireHeadersAndBody/>
+      </wsp:Policy>
+   </sp:SymmetricBinding>
+   <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <wsp:Policy>
+         <sp:SamlToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+            <wsp:Policy>
+               <sp:WssSamlV11Token11/>
+            </wsp:Policy>
+         </sp:SamlToken>
+      </wsp:Policy>
+   </sp:SignedSupportingTokens>
+   <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <wsp:Policy>
+         <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+            <wsp:Policy>
+               <sp:WssX509V3Token11/>
+            </wsp:Policy>
+         </sp:X509Token>
+      </wsp:Policy>
+   </sp:EndorsingSupportingTokens>
+   <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+      <wsp:Policy>
+         <sp:RequireSignatureConfirmation/>
+         <sp:MustSupportRefEncryptedKey/>
+      </wsp:Policy>
+   </sp:Wss11>
+</wsp:Policy>    <wsdl:import namespace="http://xmlns.oracle.com/adf/svc/errors/" location="ServiceException.wsdl"/>
+    <wsdl:types>
+        <schema xmlns="http://www.w3.org/2001/XMLSchema">
+            <import namespace="http://xmlns.oracle.com/oracleas/schema/oracle-fault-11_0" schemaLocation="oracle-webservices-async-fault-11_0.xsd"/>
+            <import namespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/types/"
+                 schemaLocation="SupplierService.xsd"/>
+        </schema>
+    </wsdl:types>
+    <wsdl:message name="SupplierService_updateSupplier">
+        <wsdl:part name="parameters" element="types:updateSupplier"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_updateSupplierResponse">
+        <wsdl:part name="parameters" element="types:updateSupplierResponse"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_createSupplier">
+        <wsdl:part name="parameters" element="types:createSupplier"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_createSupplierResponse">
+        <wsdl:part name="parameters" element="types:createSupplierResponse"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_createSupplierAsync">
+        <wsdl:part name="parameters" element="types:createSupplierAsync"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_updateSupplierAsync">
+        <wsdl:part name="parameters" element="types:updateSupplierAsync"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_onFault">
+        <wsdl:part name="parameters" element="orafault:Fault"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_createSupplierAsyncResponse">
+        <wsdl:part name="parameters" element="types:createSupplierAsyncResponse"/>
+    </wsdl:message>
+    <wsdl:message name="SupplierService_updateSupplierAsyncResponse">
+        <wsdl:part name="parameters" element="types:updateSupplierAsyncResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="SupplierService">
+        <wsdl:documentation/>
+        <wsdl:operation name="updateSupplier">
+            <wsdl:input message="tns:SupplierService_updateSupplier"/>
+            <wsdl:output message="tns:SupplierService_updateSupplierResponse"/>
+            <wsdl:fault name="ServiceException" message="errors:ServiceException"/>
+        </wsdl:operation>
+        <wsdl:operation name="createSupplier">
+            <wsdl:input message="tns:SupplierService_createSupplier"/>
+            <wsdl:output message="tns:SupplierService_createSupplierResponse"/>
+            <wsdl:fault name="ServiceException" message="errors:ServiceException"/>
+        </wsdl:operation>
+        <wsdl:operation name="createSupplierAsync">
+            <wsdl:input message="tns:SupplierService_createSupplierAsync" xmlns:ns1="http://www.w3.org/2006/05/addressing/wsdl"
+                 ns1:Action="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/createSupplierAsync"/>
+        </wsdl:operation>
+        <wsdl:operation name="updateSupplierAsync">
+            <wsdl:input message="tns:SupplierService_updateSupplierAsync" xmlns:ns1="http://www.w3.org/2006/05/addressing/wsdl"
+                 ns1:Action="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/updateSupplierAsync"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:portType name="SupplierServiceResponse">
+        <wsdl:operation name="onFault">
+            <wsdl:input message="tns:SupplierService_onFault" xmlns:ns1="http://www.w3.org/2006/05/addressing/wsdl"
+                 ns1:Action="http://xmlns.oracle.com/oracleas/schema/oracle-fault-11_0/Fault"/>
+        </wsdl:operation>
+        <wsdl:operation name="createSupplierAsyncResponse">
+            <wsdl:input message="tns:SupplierService_createSupplierAsyncResponse" xmlns:ns1="http://www.w3.org/2006/05/addressing/wsdl"
+                 ns1:Action="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/createSupplierAsyncResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="updateSupplierAsyncResponse">
+            <wsdl:input message="tns:SupplierService_updateSupplierAsyncResponse" xmlns:ns1="http://www.w3.org/2006/05/addressing/wsdl"
+                 ns1:Action="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/updateSupplierAsyncResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SupplierServiceResponseBinding" type="tns:SupplierServiceResponse">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#wss11_saml_token_with_message_protection_client_policy" wsdl:required="false"/>
+        <wsdl:operation name="onFault">
+            <soap:operation soapAction="http://xmlns.oracle.com/oracleas/schema/oracle-fault-11_0/Fault"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceResponse_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="createSupplierAsyncResponse">
+            <soap:operation soapAction="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/createSupplierAsyncResponse"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceResponse_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="updateSupplierAsyncResponse">
+            <soap:operation soapAction="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/updateSupplierAsyncResponse"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceResponse_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="SupplierServiceSoapHttp" type="tns:SupplierService">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#wss11_saml_or_username_token_with_message_protection_service_policy" wsdl:required="false"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#wsaddr_policy" wsdl:required="false"/>
+        <wsdl:operation name="updateSupplier">
+            <soap:operation soapAction="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/updateSupplier"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Output_Policy" wsdl:required="false"/>
+            </wsdl:output>
+            <wsdl:fault name="ServiceException">
+                <soap:fault name="ServiceException" use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Fault_Policy" wsdl:required="false"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="createSupplier">
+            <soap:operation soapAction="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/createSupplier"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Output_Policy" wsdl:required="false"/>
+            </wsdl:output>
+            <wsdl:fault name="ServiceException">
+                <soap:fault name="ServiceException" use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Fault_Policy" wsdl:required="false"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="createSupplierAsync">
+            <soap:operation soapAction="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/createSupplierAsync"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="updateSupplierAsync">
+            <soap:operation soapAction="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/updateSupplierAsync"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="#SupplierServiceSoapHttpPort_Input_Policy" wsdl:required="false"/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SupplierService">
+        <wsdl:port name="SupplierServiceSoapHttpPort" binding="tns:SupplierServiceSoapHttp">
+            <soap:address location="https://eeli-test.fa.us2.oraclecloud.com:443/fscmService/SupplierServiceV2"/>
+            <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+                <wsa:Address xmlns:wsa="http://www.w3.org/2005/08/addressing">https://eeli-test.fa.us2.oraclecloud.com:443/fscmService/SupplierServiceV2</wsa:Address>
+                <wsid:Identity xmlns:wsid="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+                    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+                        <dsig:X509Data>
+                            <dsig:X509Certificate>MIIDVzCCAj+gAwIBAgIIVg/+Q6HleUswDQYJKoZIhvcNAQELBQAwWTETMBEGCgmSJomT8ixkARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBm9yYWNsZTEVMBMGCgmSJomT8ixkARkWBWNsb3VkMRMwEQYDVQQDEwpDbG91ZDlDQS0yMB4XDTE2MDUyMTAyMTgxMVoXDTI2MDUxOTAyMTgxMVowWzETMBEGCgmSJomT8ixkARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBm9yYWNsZTEVMBMGCgmSJomT8ixkARkWBWNsb3VkMRUwEwYDVQQDEwxGQUVuY3J5cHRpb24wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCXkkCRaPrzPLVxYvo6yqAMrcduV0+Ghq6NCdXAhKdbAXkc6yfFJPpYKDTEooxEUVZUkcfzZ+N3kJq6fTcQifkHPhobN5SHHSAprBWTrwDPjuQtrOC+NxB4wb02tQD/RV722MaUmzIVUrxEcY4hr0SADaqTT+4kvGysNwfxBRrRACs3fY3B41B6qL85ZiWq5GBUdjqEJqpdCWKa2fYiRDDiWXQcGwf3HNETR1QMi20/HjUSwURZLAUoGZAvLpnc9Va5WD3VKfpQ+BME6gs/jCuKKKd5lzm1sn08rT+H7vbT8JfkHL4sbHMhTgSV7HVh7SCOeLY5/kyLmcDxGpAEWEs/AgMBAAGjITAfMB0GA1UdDgQWBBRe0RelArN2TGMOMSDshZ/yxiLr/jANBgkqhkiG9w0BAQsFAAOCAQEArJa3QUFptgahgBUHiXQ0Xsl1yGHgp7x0RqYUVFuIId3ojpASaN1hWY7Ze7gUC7yELqDj/w+z9fXa7ce7S9tMbPL82/pvoh48N8kEOeCkvFrww+XCKu0ywbjNKzejsl4hWr6t0Ej1cZ2cBrzz0V42acUBwtIDeRBD0VWffA0EEF9uRyOByErHg5yAcl+2n6vnwvhRHMRNNXn2r2ueRyu+nKKl3upWijgJDiWHcaCXZf/HCju1XgnZV+g5t4//R2dDMoBzhWqY9rIcO+7yYFGwyADrao0NqwQk9Vco4KC3I4fWyi+EZalBCUx31sMhTYopy5qOqnlWsCVd/6g75ce9DA==</dsig:X509Certificate>
+                            <dsig:X509IssuerSerial>
+                                <dsig:X509IssuerName>CN=Cloud9CA-2, DC=cloud, DC=oracle, DC=com</dsig:X509IssuerName>
+                                <dsig:X509SerialNumber>6201454778344896843</dsig:X509SerialNumber>
+                            </dsig:X509IssuerSerial>
+                            <dsig:X509SubjectName>CN=FAEncryption, DC=cloud, DC=oracle, DC=com</dsig:X509SubjectName>
+                            <dsig:X509SKI>XtEXpQKzdkxjDjEg7IWf8sYi6/4=</dsig:X509SKI>
+                            <dsig:X509Certificate>MIIDazCCAlOgAwIBAgIIMdQl7kIMrv0wDQYJKoZIhvcNAQELBQAwWTETMBEGCgmSJomT8ixkARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBm9yYWNsZTEVMBMGCgmSJomT8ixkARkWBWNsb3VkMRMwEQYDVQQDEwpDbG91ZDlDQS0yMCAXDTE2MDUyMTAyMTgwOVoYDzIxMTYwNDI3MDIxODA5WjBZMRMwEQYKCZImiZPyLGQBGRYDY29tMRYwFAYKCZImiZPyLGQBGRYGb3JhY2xlMRUwEwYKCZImiZPyLGQBGRYFY2xvdWQxEzARBgNVBAMTCkNsb3VkOUNBLTIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDPZn2VAoMsIfWmIJks9exzK+DXaX6qYyBc12dRqDrRpC48v3CBeBchV/GT2E+mjcDp8Hzq8oIpwr9W5kwMja4PU3SPd4/0LB6WKbtLfHOnJxLg9EaT992UpbUGHaHlEq4oRAuVvPgDLp5sSspLZYEBKUh4vJXOyLitE1qsXn7mJNXRKTJZvrJKdfbs1dyTge3V3wk1rwY/wCWMKVgkqCgSzzWCGju8EZWoOrnzlR6BHkA0qZqeV4F7jDW8ucdv+Y20pOlOiaEbIg/ZFYGrZd5VWjlNvgLfU8P4C/YJLSkkcPHgoet3w4jI0S26efu59rVzgU9VsKnKtnqbDL99t81vAgMBAAGjNTAzMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFDMA8e55FI5kC12+guIE9xtcIXpFMA0GCSqGSIb3DQEBCwUAA4IBAQC45tOVeqHxA8Bo/Rnv1SHHpULge3HyTC1XV9nmUdrj6g/U6rmbA5hVJ5LshgQ77qopO/YsaNHj5Ru1u/+8VOlZWpbn+kt3CDOuBUCe89CKBZT/KWEDkvtNl2qu16gOkhFnuTQk8NsARvwZZ6KtyPDmsbW4Nc/I5fKwPhdTaMjCV6Lh9RCG4kU77lbdwY3SaXlCBXXQyfPWMouCi7z1thJaF3cNGW4tnsibMR5ej9fJ9j6UvShxNgAIgjNDoihPlC6k0kW3QDR3bBjCHJX47505aIhckojH/eKsP2Or0eE/Ma4WNbndj0IXPE2ae5AVmC8/GRtwAmnoZPnt3g/I2m5j</dsig:X509Certificate>
+                        </dsig:X509Data>
+                    </dsig:KeyInfo>
+                </wsid:Identity>
+            </wsa:EndpointReference>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/core/src/test/resources/supplier-service-v2/SupplierSiteAssignments.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierSiteAssignments.xsd
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:sdoJava="commonj.sdo/java" xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Site Assignment</name>
+            <description>Entity that models the requisitioning business units that are
+                governed by the procurement business unit and the site it
+                belongs to. The terms and conditions defined at the site are
+                applicable to these business units</description>
+            <oer:category name="lba">
+                <value>PrcTop-Procurement</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model</value>
+                <value>PrcTop-Procurement : PrcPozTop-Supplier Model :
+                    PrcPozSuppliers-Suppliers</value>
+            </oer:category>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Supplier site assignment record unique identifier." name="SiteAssignmentId"/>
+                <oer:attribute description="Unique identifier of a client BU on a site assignment record."
+                     name="ClientBUId"/>
+                <oer:attribute description="Client business unit identified for a supplier site assignment record."
+                     name="ClientBU"/>
+                <oer:attribute description="Unique identifier of a bill to business unit on a site assignment record."
+                     name="BillToBUId"/>
+                <oer:attribute description="Identifies the bill to business unit on a site assignment record."
+                     name="BillToBU"/>
+                <oer:attribute description="Unique identifier of a ship to location on a site assignment record."
+                     name="ShipToLocationId"/>
+                <oer:attribute description="Ship to location on a site assignment record." name="ShipToLocation"/>
+                <oer:attribute description="Unique identifier of a bill to location on a site assignment record."
+                     name="BillToLocationId"/>
+                <oer:attribute description="Unique identifier of a bill to location on a site assignment record."
+                     name="BillToLocation"/>
+                <oer:attribute description="Whether withholding tax is applicable to the supplier for the specified bill to BU."
+                     name="UseWithholdingTaxFlag"/>
+                <oer:attribute description="Unique withholding tax group identifier on a site assignment record."
+                     name="WithholdingTaxGroupId"/>
+                <oer:attribute description="Identifies the withholding tax group assigned to the supplier site assignment record."
+                     name="WithholdingTaxGroup"/>
+                <oer:attribute description="Unique liability account identifier on a site assignment record."
+                     name="LiabilityDistributionId"/>
+                <oer:attribute description="Liability account on a site assignment record." name="LiabilityDistributionConcatSegments"/>
+                <oer:attribute description="Unique prepayment account identifier on a site assignment record."
+                     name="PrepaymentDistributionId"/>
+                <oer:attribute description="Prepayment account on a site assignment record." name="PrepaymentDistributionConcatSegments"/>
+                <oer:attribute description="Unique bills payable account identifier on a site assignment record."
+                     name="BillPayableDistributionId"/>
+                <oer:attribute description="Bills payable account on a site assignment record." name="BillsPayableDistributionConcatSegments"/>
+                <oer:attribute description="Unique distribution set identifier on a site assignment record."
+                     name="DistributionSetId"/>
+                <oer:attribute description="Distribution set on a site assignment record." name="DistributionSet"/>
+                <oer:attribute description="Date on which the site assignment becomes inactive." name="InactiveDate"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:complexType name="SupplierSiteAssignmentsResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierSiteAssignments"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierSiteAssignments">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>AssignmentInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SiteAssignmentId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ClientBUId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ClientBU" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BillToBUId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="BillToBU" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ShipToLocationId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ShipToLocation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BillToLocationId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="BillToLocation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="UseWithholdingTaxFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="WithholdingTaxGroupId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="WithholdingTaxGroup" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="LiabilityDistributionId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="LiabilityDistributionConcatSegments" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PrepaymentDistributionId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="PrepaymentDistributionConcatSegments" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BillPayableDistributionId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="BillsPayableDistributionConcatSegments" nillable="true"
+                 type="xsd:string"/>
+            <xsd:element minOccurs="0" name="DistributionSetId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="DistributionSet" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InactiveDate" nillable="true" type="ns0:date-Date"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="supplierSiteAssignments" type="SupplierSiteAssignments"/>
+    <xsd:element name="supplierSiteAssignmentsResult" type="SupplierSiteAssignmentsResult"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/SupplierSites.xsd
+++ b/core/src/test/resources/supplier-service-v2/SupplierSites.xsd
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/"
+     sdoJava:package="oracle.apps.prc.poz.suppliers.supplierServiceV2" xmlns:ns0="http://xmlns.oracle.com/adf/svc/types/"
+     xmlns:ns1="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/"
+     xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java" xmlns:sdoXML="commonj.sdo/xml"
+     xmlns="http://xmlns.oracle.com/apps/prc/poz/suppliers/supplierServiceV2/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:annotation>
+        <xsd:documentation xmlns:oer="http://xmlns.oracle.com/oer">
+            <name>Supplier Site</name>
+            <description>Entity that captures the business relationship between a
+                procurement business unit in a buying organization and the
+                supplier. The site captures business terms and conditions as
+                negotiated by the business unit with the supplier.</description>
+            <oer:attributes>
+                <oer:attribute description="Indicates the action that needs to be taken for the specific record in the web service."
+                     name="Operation"/>
+                <oer:attribute description="Supplier site record unique identifier." name="SiteId"/>
+                <oer:attribute description="Name of the supplier site. The name is unique within a procurement BU."
+                     name="SiteName"/>
+                <oer:attribute description="Updated name for the supplier site." name="SiteNameNew"/>
+                <oer:attribute description="Unique identifier of a supplier address identified by the column PARTY_SIDE_ID in TCA."
+                     name="AddressId"/>
+                <oer:attribute description="Supplier address identifier." name="AddressName"/>
+                <oer:attribute description="Identifies the procurement BU to which a site belongs. This attribute combined with SiteName constitutes a unique site identifier."
+                     name="ProcurementBUId"/>
+                <oer:attribute description="The business unit to which the supplier site is associated."
+                     name="ProcurementBU"/>
+                <oer:attribute description="Date on which the supplier site becomes inactive." name="InactiveDate"/>
+                <oer:attribute description="Indicates whether the supplier site  is enabled for Sourcing transactions."
+                     name="SourcingOnlyPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier site can be used for purchasing."
+                     name="PurchasingPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier site can be enabled for Procurement Card transactions."
+                     name="ProcurementCardPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier site is the primary pay site."
+                     name="PayPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier site is the primary pay site."
+                     name="PrimaryPayPurposeFlag"/>
+                <oer:attribute description="Indicates whether the supplier site is a tax reporting site."
+                     name="IncomeTaxReportingSiteFlag"/>
+                <oer:attribute description="Alternate name of the supplier site." name="AlternateSiteName"/>
+                <oer:attribute description="An identifier used by the supplier to identify the buying organization&apos;s site."
+                     name="CustomerNumber"/>
+                <oer:attribute description="The communication method used for documents in B2B procurement transactions."
+                     name="B2BCommunicationMethod"/>
+                <oer:attribute description="The B2B unique identifier for B2B document communication."
+                     name="B2bSupplierSiteCode"/>
+                <oer:attribute description="Indicates the preferred method of notification for suppliers. This is used if set for a supplier site, as a default on purchasing documents. Seeded values are NONE, FAX, EMAIL and PRINT."
+                     name="CommunicationMethod"/>
+                <oer:attribute description="E-Mail address if the communication method on the supplier site is EMAIL."
+                     name="EmailAddress"/>
+                <oer:attribute description="Fax country code if the communication method on the supplier site is FAX."
+                     name="FaxCountryCode"/>
+                <oer:attribute description="Fax area code if the communication method on the supplier site is FAX."
+                     name="FaxAreaCode"/>
+                <oer:attribute description="Fax number for communication method of Fax on a supplier site."
+                     name="Fax"/>
+                <oer:attribute description="Indicates whether the supplier site  is enabled for Sourcing transactions."
+                     name="HoldAllNewPurchasingDocumentsFlag"/>
+                <oer:attribute description="Indicates the reason why the supplier site is being placed on purchasing hold."
+                     name="HoldReason"/>
+                <oer:attribute description="Carrier unique identifier." name="CarrierId"/>
+                <oer:attribute description="Carrier name that indicates the shipping method used on the supplier site."
+                     name="Carrier"/>
+                <oer:attribute description="Attribute that is part of the carrier definition used to define a shipping method on a supplier site."
+                     name="ModeOfTransport"/>
+                <oer:attribute description="Attribute that is part of the carrier definition used to define a shipping method on a supplier site."
+                     name="ServiceLevel"/>
+                <oer:attribute description="Freight terms for the supplier site." name="FreightTerms"/>
+                <oer:attribute description="Indicates whether the supplier site support pay on receipt. Valid values are Y or N."
+                     name="PayOnReceiptFlag"/>
+                <oer:attribute description="Free on board setting on the supplier site." name="FOB"/>
+                <oer:attribute description="Country of origin setup on the supplier site for freight computations."
+                     name="CountryOfOrigin"/>
+                <oer:attribute description="Indicates whether the transportation is managed by the buyer. Valid values are Null, Y and N."
+                     name="BuyerManagedTransportationFlag"/>
+                <oer:attribute description="Indicates whether the supplier site supports pay on use. Valid values are Y or N."
+                     name="PayOnUseFlag"/>
+                <oer:attribute description="Indicates the mutually agreed event point between the supplier and the buying organization at which consigned material begins to age."
+                     name="AgingOnsetPoint"/>
+                <oer:attribute description="The setting that defines the maximum number of days that material can be on consignment."
+                     name="AgingPeriodDays"/>
+                <oer:attribute description="The frequency at which the &apos;Create Consumption Advice&apos; program will be run for  all consumption transactions for consigned inventory purchased under one  agreement."
+                     name="ConsumptionAdviceFrequency"/>
+                <oer:attribute description="The granularity at which consumption advices will be generated."
+                     name="ConsumptionAdviceSummary"/>
+                <oer:attribute description="Unique identifier of an alternate pay site." name="AlternatePaySiteId"/>
+                <oer:attribute description="Name of the alternate pay site. The name is unique within a procurement BU for a given supplier."
+                     name="AlternatePaySite"/>
+                <oer:attribute description="Indicates how invoices of this supplier site would be grouped and summarised during creation."
+                     name="InvoiceSummaryLevel"/>
+                <oer:attribute description="Indicates if the invoice sequencing should be gap less."
+                     name="GaplessInvoiceNumberingFlag"/>
+                <oer:attribute description="Unique selling company identifier and is required to be used if using gap less invoice  numbering."
+                     name="SellingCompanyIdentifier"/>
+                <oer:attribute description="Indicates if a debit memo should be created from the return transaction for this supplier site."
+                     name="CreateDebitMemoFromReturnFlag"/>
+                <oer:attribute description="Indicates the action that needs to be taken if the receiving location differs from the original ship-to location."
+                     name="ShipToExceptionAction"/>
+                <oer:attribute description="Indicates how the system should route receipts for this supplier site."
+                     name="ReceiptRouting"/>
+                <oer:attribute description="Indicates what the allowed tolerance is set at for over receiving."
+                     name="OverReceiptTolerance"/>
+                <oer:attribute description="Indicates the action to be taken in case of an over receipt that is outside the tolerance level set."
+                     name="OverReceiptAction"/>
+                <oer:attribute description="Indicates the threshold limit set for early receipts."
+                     name="EarlyReceiptToleranceInDays"/>
+                <oer:attribute description="Indicates the threshold limit set for late receipts."
+                     name="LateReceiptToleranceInDays"/>
+                <oer:attribute description="Indicates if substitute receipts is permitted for this supplier site."
+                     name="AllowSubstituteReceiptsFlag"/>
+                <oer:attribute description="Indicates if unordered receipts is permitted for this supplier site."
+                     name="AllowUnorderedReceiptsFlag"/>
+                <oer:attribute description="Indicates the action to be taken if items are received outside the tolerance days set for this supplier site."
+                     name="ReceiptDateException"/>
+                <oer:attribute description="Indicates the currency in which the invoice is created."
+                     name="InvoiceCurrency"/>
+                <oer:attribute description="Indicates the default currency for invoices generated for this supplier site."
+                     name="InvoiceAmountLimit"/>
+                <oer:attribute description="Indicates if the invoice is to be matched against a purchase order, receipt or a consumption advice."
+                     name="InvoiceMatchOption"/>
+                <oer:attribute description="Indicates how an invoice is to be matched for payment purposes."
+                     name="MatchApprovalLevel"/>
+                <oer:attribute description="Indicates the currency in which payment for an invoice is to be made."
+                     name="PaymentCurrency"/>
+                <oer:attribute description="Indicates the priority to be assigned to an invoice during a payment run."
+                     name="PaymentPriority"/>
+                <oer:attribute description="Unique withholding tax group identifier on a site assignment record."
+                     name="PayGroup"/>
+                <oer:attribute description="Unique identifier of the tolerance value setup for quantity variances on an invoice."
+                     name="QuantityTolerancesId"/>
+                <oer:attribute description="The tolerance levels to be applied to quantity when an invoice is created for this supplier site."
+                     name="QuantityTolerances"/>
+                <oer:attribute description="Unique identifier of the tolerance value setup for invoice amount variances."
+                     name="AmountTolerancesId"/>
+                <oer:attribute description="The tolerance levels to be applied to invoice amount when an invoice is created for this supplier site."
+                     name="AmountTolerances"/>
+                <oer:attribute description="Indicates if all invoices generated for the supplier site should be put on system hold."
+                     name="HoldAllInvoicesFlag"/>
+                <oer:attribute description="Indicates if all unmatched invoices generated for the supplier site should be put on system hold."
+                     name="HoldUnmatchedInvoices"/>
+                <oer:attribute description="Indicates if all unvalidated invoices generated for the supplier site should be put on system hold."
+                     name="HoldUnvalidatedInvoicesFlag"/>
+                <oer:attribute description="Indicates the date on which the supplier site was placed on invoice hold. This attribute is used only when the user updates the attribute HoldUnmatchedInvoices."
+                     name="PaymentHoldDate"/>
+                <oer:attribute description="Indicates the reason that the invoices generated for this supplier site are placed on hold."
+                     name="PaymentHoldReason"/>
+                <oer:attribute description="Payment terms unique identifier." name="PaymentTermsId"/>
+                <oer:attribute description="Payment terms for the supplier site." name="PaymentTerms"/>
+                <oer:attribute description="Indicates the date from which payment due is computed on an invoice."
+                     name="TermsDateBasis"/>
+                <oer:attribute description="Indicates the date from which payment run is to be scheduled for invoices."
+                     name="PayDateBasis"/>
+                <oer:attribute description="Indicates whether and how bank charges are to be deducted during payment of an invoice. Valid values are D, N, X and S."
+                     name="BankChargeDeductionType"/>
+                <oer:attribute description="Indicates if discount should be availed automatically on payment. Valid values are Y, N and D."
+                     name="AlwaysTakeDiscount"/>
+                <oer:attribute description="Indicates if freight should be excluded from discount calculations. Valid values are Y, N and D."
+                     name="ExcludeFreightFromDiscount"/>
+                <oer:attribute description="Indicates if tax should be excluded from discount calculations. Valid values are Y, N and D."
+                     name="ExcludeTaxFromDiscount"/>
+                <oer:attribute description="Indicates if interest invoices are to be created automatically. Valid values are Y, N and D."
+                     name="CreateInterestInvoices"/>
+                <oer:attribute description="Indicates if the purchasing document created using this supplier site requires acknowledgment and the mode of acknowledgment. Valid values are  &apos;D&apos;, &apos;Y&apos; and &apos;N&apos; where D is for &apos;Documents&apos;, Y is for &apos;Documents and Schedule&apos; and N is for None."
+                     name="RequiredAcknowledgement"/>
+                <oer:attribute description="Indicates the number of days within which the acknowledge on the purchasing document is to be provided."
+                     name="AcknowledgeWithinDays"/>
+                <oer:attribute description="Supplier site attribute to capture the invoice channel information."
+                     name="InvoiceChannel"/>
+                <oer:attribute description="Entity that models the requisitioning business units that are governed by the procurement business unit and the site it belongs to. The terms and conditions defined at the site are applicable to these business units."
+                     name="SupplierSiteAssignments"/>
+                <oer:attribute description="An object that enables customers to extend the supplier sites information."
+                     name="SupplierSitesFlexField"/>
+            </oer:attributes>
+        </xsd:documentation>
+    </xsd:annotation>
+    <xsd:import namespace="http://xmlns.oracle.com/adf/svc/types/" schemaLocation="BC4JService.xsd"/>
+    <xsd:import namespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/"
+         schemaLocation="PozSupplierSitesIntDFF.xsd"/>
+    <xsd:import namespace="commonj.sdo/java" schemaLocation="sdoJava.xsd"/>
+    <xsd:import namespace="commonj.sdo/xml" schemaLocation="sdoXML.xsd"/>
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:include schemaLocation="SupplierSiteAssignments.xsd"/>
+    <xsd:complexType name="SupplierSites">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorSiteInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="Operation" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SiteId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="SiteName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="SiteNameNew" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AddressId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="AddressName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ProcurementBUId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="ProcurementBU" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InactiveDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="SourcingOnlyPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="PurchasingPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="ProcurementCardPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="PayPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="PrimaryPayPurposeFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="IncomeTaxReportingSiteFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="AlternateSiteName" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CustomerNumber" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="B2BCommunicationMethod" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="B2bSupplierSiteCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CommunicationMethod" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="EmailAddress" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FaxCountryCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FaxAreaCode" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Fax" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="HoldAllNewPurchasingDocumentsFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="HoldReason" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CarrierId" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="Carrier" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ModeOfTransport" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ServiceLevel" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="FreightTerms" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PayOnReceiptFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="FOB" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CountryOfOrigin" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BuyerManagedTransportationFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="PayOnUseFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="AgingOnsetPoint" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AgingPeriodDays" nillable="true" type="xsd:int"/>
+            <xsd:element minOccurs="0" name="ConsumptionAdviceFrequency" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ConsumptionAdviceSummary" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AlternatePaySiteId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="AlternatePaySite" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InvoiceSummaryLevel" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="GaplessInvoiceNumberingFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="SellingCompanyIdentifier" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CreateDebitMemoFromReturnFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="ShipToExceptionAction" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ReceiptRouting" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="OverReceiptTolerance" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="OverReceiptAction" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="EarlyReceiptToleranceInDays" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="LateReceiptToleranceInDays" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="AllowSubstituteReceiptsFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="AllowUnorderedReceiptsFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="ReceiptDateException" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InvoiceCurrency" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="InvoiceAmountLimit" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="InvoiceMatchOption" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="MatchApprovalLevel" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PaymentCurrency" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PaymentPriority" nillable="true" type="xsd:decimal"/>
+            <xsd:element minOccurs="0" name="PayGroup" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="QuantityTolerancesId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="QuantityTolerances" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AmountTolerancesId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="AmountTolerances" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="HoldAllInvoicesFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="HoldUnmatchedInvoices" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="HoldUnvalidatedInvoicesFlag" nillable="true" type="xsd:boolean"/>
+            <xsd:element minOccurs="0" name="PaymentHoldDate" nillable="true" type="ns0:date-Date"/>
+            <xsd:element minOccurs="0" name="PaymentHoldReason" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PaymentTermsId" nillable="true" type="xsd:long"/>
+            <xsd:element minOccurs="0" name="PaymentTerms" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="TermsDateBasis" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="PayDateBasis" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="BankChargeDeductionType" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AlwaysTakeDiscount" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ExcludeFreightFromDiscount" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="ExcludeTaxFromDiscount" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="CreateInterestInvoices" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="RequiredAcknowledgement" nillable="true" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="AcknowledgeWithinDays" nillable="true" type="xsd:int"/>
+            <xsd:element minOccurs="0" name="InvoiceChannel" nillable="true" type="xsd:string"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SupplierSiteAssignments" type="SupplierSiteAssignments"/>
+            <xsd:element minOccurs="0" name="SupplierSitesFlexField" type="ns1:PozSupplierSitesIntDFF"
+                 sdoXML:dataType="sdo:DataObject"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SupplierSitesResult">
+        <xsd:complexContent>
+            <xsd:extension base="ns0:MethodResult">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Value" type="SupplierSites"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="supplierSites" type="SupplierSites"/>
+    <xsd:element name="supplierSitesResult" type="SupplierSitesResult"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/TipoDeProveedor.xsd
+++ b/core/src/test/resources/supplier-service-v2/TipoDeProveedor.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/"
+     xmlns="http://xmlns.oracle.com/apps/flex/prc/poz/suppliers/supplierServiceV2/supplierSites/"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:include schemaLocation="PozSupplierSitesIntDFF.xsd"/>
+    <xsd:complexType name="TipoDeProveedor">
+        <xsd:annotation>
+            <xsd:appinfo source="http://xmlns.oracle.com/adf/svc/metadata/">
+                <key xmlns="http://xmlns.oracle.com/adf/svc/metadata/">
+                    <attribute>VendorSiteInterfaceId</attribute>
+                </key>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="PozSupplierSitesIntDFF">
+                <xsd:sequence>
+                    <xsd:element minOccurs="0" name="tipoDeProveedor" nillable="true" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="tipoDeProveedor" type="TipoDeProveedor"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/datagraph.xsd
+++ b/core/src/test/resources/supplier-service-v2/datagraph.xsd
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema targetNamespace="commonj.sdo" xmlns:sdo="commonj.sdo" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="datagraph" type="sdo:DataGraphType"/>
+    <xsd:complexType name="DataGraphType">
+        <xsd:complexContent>
+            <xsd:extension base="sdo:BaseDataGraphType">
+                <xsd:sequence>
+                    <xsd:any maxOccurs="1" minOccurs="0" namespace="##other" processContents="lax"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType abstract="true" name="BaseDataGraphType">
+        <xsd:sequence>
+            <xsd:element minOccurs="0" name="models" type="sdo:ModelsType"/>
+            <xsd:element minOccurs="0" name="xsd" type="sdo:XSDType"/>
+            <xsd:element minOccurs="0" name="changeSummary" type="sdo:ChangeSummaryType"/>
+        </xsd:sequence>
+        <xsd:anyAttribute namespace="##other" processContents="lax"/>
+    </xsd:complexType>
+    <xsd:complexType name="ModelsType">
+        <xsd:annotation>
+            <xsd:documentation>Expected type is emof:Package.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="XSDType">
+        <xsd:annotation>
+            <xsd:documentation>Expected type is xsd:schema.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="http://www.w3.org/2001/XMLSchema"
+                 processContents="lax"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ChangeSummaryType">
+        <xsd:sequence>
+            <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="lax"/>
+        </xsd:sequence>
+        <xsd:attribute name="create" type="xsd:string"/>
+        <xsd:attribute name="delete" type="xsd:string"/>
+        <xsd:attribute name="logging" type="xsd:boolean"/>
+    </xsd:complexType>
+    <xsd:attribute name="ref" type="xsd:string"/>
+    <xsd:attribute name="unset" type="xsd:string"/>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/oracle-webservices-async-fault-11_0.xsd
+++ b/core/src/test/resources/supplier-service-v2/oracle-webservices-async-fault-11_0.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema targetNamespace="http://xmlns.oracle.com/oracleas/schema/oracle-fault-11_0" xmlns:orafault="http://xmlns.oracle.com/oracleas/schema/oracle-fault-11_0"
+     xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:complexType name="FaultType">
+        <xsd:sequence>
+            <xsd:element name="faultcode" type="xsd:QName"/>
+            <xsd:element name="faultstring" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="faultactor" type="xsd:anyURI"/>
+            <xsd:element minOccurs="0" name="detail" type="orafault:detail"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="detail">
+        <xsd:sequence>
+            <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="lax"/>
+        </xsd:sequence>
+        <xsd:anyAttribute namespace="##any" processContents="lax"/>
+    </xsd:complexType>
+    <xsd:element name="Fault" type="orafault:FaultType"/>
+</schema>

--- a/core/src/test/resources/supplier-service-v2/sdoJava.xsd
+++ b/core/src/test/resources/supplier-service-v2/sdoJava.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema targetNamespace="commonj.sdo/java" xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:attribute name="package" type="xsd:string"/>
+    <xsd:attribute name="instanceClass" type="xsd:string"/>
+    <xsd:attribute name="extendedInstanceClass" type="xsd:string"/>
+    <xsd:attribute name="nestedInterfaces" type="xsd:boolean"/>
+    <xsd:attribute name="javaClass" type="sdo:String"/>
+    <xsd:complexType name="JavaInfo">
+        <xsd:attribute name="javaClass" type="sdo:String"/>
+    </xsd:complexType>
+    <xsd:simpleType name="BooleanObject" sdoJava:instanceClass="java.lang.Boolean">
+        <xsd:restriction base="xsd:boolean"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="ByteObject" sdoJava:instanceClass="java.lang.Byte">
+        <xsd:restriction base="xsd:byte"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="CharacterObject" sdoJava:instanceClass="java.lang.Character">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="DoubleObject" sdoJava:instanceClass="java.lang.Double">
+        <xsd:restriction base="xsd:double"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="FloatObject" sdoJava:instanceClass="java.lang.Float">
+        <xsd:restriction base="xsd:float"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="IntObject" sdoJava:instanceClass="java.lang.Integer">
+        <xsd:restriction base="xsd:int"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="LongObject" sdoJava:instanceClass="java.lang.Long">
+        <xsd:restriction base="xsd:long"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="ShortObject" sdoJava:instanceClass="java.lang.Short">
+        <xsd:restriction base="xsd:short"/>
+    </xsd:simpleType>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/sdoModel.xsd
+++ b/core/src/test/resources/supplier-service-v2/sdoModel.xsd
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="commonj.sdo" xmlns:sdo="commonj.sdo" xmlns:sdoJava="commonj.sdo/java"
+     xmlns:sdoXML="commonj.sdo/xml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="commonj.sdo/xml sdoXML.xsd                   commonj.sdo/java sdoJava.xsd">
+    <xsd:include schemaLocation="datagraph.xsd"/>
+    <xsd:element name="types" type="sdo:Types"/>
+    <xsd:complexType name="Types">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="type" type="sdo:Type"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="dataObject" type="xsd:anyType"/>
+    <xsd:element name="type" type="sdo:Type"/>
+    <xsd:complexType name="Type">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="baseType" type="sdo:URI" sdoXML:propertyType="sdo:Type"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="property" type="sdo:Property"/>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="aliasName" type="sdo:String"/>
+            <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+        </xsd:sequence>
+        <xsd:attribute name="name" type="xsd:ID" sdoXML:dataType="sdo:String"/>
+        <xsd:attribute name="uri" type="sdo:URI"/>
+        <xsd:attribute name="dataType" type="sdo:Boolean"/>
+        <xsd:attribute name="open" type="sdo:Boolean"/>
+        <xsd:attribute name="sequenced" type="sdo:Boolean"/>
+        <xsd:attribute name="abstract" type="sdo:Boolean"/>
+        <xsd:anyAttribute namespace="##any" processContents="lax"/>
+    </xsd:complexType>
+    <xsd:complexType name="Property">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="aliasName" type="sdo:String"/>
+            <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+        </xsd:sequence>
+        <xsd:attribute name="name" type="sdo:String"/>
+        <xsd:attribute name="many" type="sdo:Boolean"/>
+        <xsd:attribute name="containment" type="sdo:Boolean"/>
+        <xsd:attribute name="default" type="sdo:String"/>
+        <xsd:attribute name="readOnly" type="sdo:Boolean"/>
+        <xsd:attribute name="type" type="sdo:URI" sdoXML:propertyType="sdo:Type"/>
+        <xsd:attribute name="opposite" type="sdo:URI" sdoXML:propertyType="sdo:Property"/>
+        <xsd:attribute name="nullable" type="sdo:Boolean"/>
+        <xsd:anyAttribute namespace="##any" processContents="lax"/>
+    </xsd:complexType>
+    <xsd:complexType abstract="true" name="DataObject"/>
+    <xsd:complexType abstract="true" name="TextType">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="text" type="xsd:string"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:simpleType name="Boolean" sdoJava:instanceClass="boolean">
+        <xsd:restriction base="xsd:boolean"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Byte" sdoJava:instanceClass="byte">
+        <xsd:restriction base="xsd:byte"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Bytes" sdoJava:instanceClass="byte[]">
+        <xsd:restriction base="xsd:hexBinary"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Character" sdoJava:instanceClass="char">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Date" sdoJava:instanceClass="java.util.Date">
+        <xsd:restriction base="xsd:dateTime"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="DateTime" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:dateTime"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Day" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:gDay"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Decimal" sdoJava:instanceClass="java.math.BigDecimal">
+        <xsd:restriction base="xsd:decimal"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Double" sdoJava:instanceClass="double">
+        <xsd:restriction base="xsd:double"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Duration" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:duration"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Float" sdoJava:instanceClass="float">
+        <xsd:restriction base="xsd:float"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Int" sdoJava:instanceClass="int">
+        <xsd:restriction base="xsd:int"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Integer" sdoJava:instanceClass="java.math.BigInteger">
+        <xsd:restriction base="xsd:integer"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Long" sdoJava:instanceClass="long">
+        <xsd:restriction base="xsd:long"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Month" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:gMonth"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="MonthDay" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:gMonthDay"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Object" sdoJava:instanceClass="java.lang.Object">
+        <xsd:union memberTypes="xsd:anyURI xsd:base64Binary xsd:boolean xsd:byte     xsd:date xsd:dateTime xsd:decimal xsd:double xsd:duration xsd:ENTITIES xsd:ENTITY xsd:float     xsd:gDay xsd:gMonth xsd:gMonthDay xsd:gYear xsd:gYearMonth xsd:hexBinary xsd:ID xsd:IDREF xsd:IDREFS     xsd:int xsd:integer xsd:language xsd:long xsd:Name xsd:NCName xsd:negativeInteger     xsd:NMTOKEN xsd:NMTOKENS xsd:nonNegativeInteger xsd:nonPositiveInteger     xsd:normalizedString xsd:NOTATION xsd:positiveInteger xsd:QName xsd:short xsd:string     xsd:time xsd:token xsd:unsignedByte xsd:unsignedInt xsd:unsignedLong xsd:unsignedShort"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Short" sdoJava:instanceClass="short">
+        <xsd:restriction base="xsd:short"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="String" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Strings" sdoJava:instanceClass="java.util.List">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Time" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:time"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Year" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:gYear"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="YearMonth" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:gYearMonth"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="YearMonthDay" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:date"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="URI" sdoJava:instanceClass="java.lang.String">
+        <xsd:restriction base="xsd:anyURI"/>
+    </xsd:simpleType>
+</xsd:schema>

--- a/core/src/test/resources/supplier-service-v2/sdoXML.xsd
+++ b/core/src/test/resources/supplier-service-v2/sdoXML.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema targetNamespace="commonj.sdo/xml" xmlns:sdo="commonj.sdo" xmlns:sdoXML="commonj.sdo/xml"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="commonj.sdo" schemaLocation="sdoModel.xsd"/>
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="propertyType" type="xsd:QName"/>
+    <xsd:attribute name="oppositeProperty" type="xsd:string"/>
+    <xsd:attribute name="sequence" type="xsd:boolean"/>
+    <xsd:attribute name="string" type="xsd:boolean"/>
+    <xsd:attribute name="dataType" type="xsd:QName"/>
+    <xsd:attribute name="aliasName" type="xsd:string"/>
+    <xsd:attribute name="readOnly" type="xsd:boolean"/>
+    <xsd:attribute name="many" type="xsd:boolean"/>
+    <xsd:attribute name="xmlElement" type="sdo:Boolean"/>
+    <xsd:complexType name="XMLInfo">
+        <xsd:attribute name="xmlElement" type="sdo:Boolean"/>
+    </xsd:complexType>
+</xsd:schema>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@ Analyze a WSDL or Schema document and generate an HMTL report</description>
 				<artifactId>commons-cli</artifactId>
 				<version>1.3.1</version>
 			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.12.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
This commit contains three things:
1. Ability to provide custom/external XMLInputFactory
2. Ability to convert external resources from ISO_8859_1 to UTF-8
3. Ability to avoid namespace prefix overrides, that may happen during "include schema" parse