### PR TITLE
improve namespace prefix evaluation logic

### DIFF
--- a/core/src/main/groovy/com/predic8/wstool/creator/RequestTemplateCreator.groovy
+++ b/core/src/main/groovy/com/predic8/wstool/creator/RequestTemplateCreator.groovy
@@ -242,7 +242,10 @@ class RequestTemplateCreator extends AbstractSchemaCreator <RequestTemplateCreat
 		/*Only if the element is from the same namespace as the 
 		* top-level-element of the request, it doesn't need a prefix.
 		*/
-		if(!element.toplevel && element.schema.elementFormDefault=="unqualified" && ctx.elements[0].namespaceUri == element.namespaceUri)
+		if(!element.toplevel 
+                && element.schema.elementFormDefault == "unqualified"
+                && ctx.elements[0].namespaceUri == element.namespaceUri
+                && getNSPrefix(element, ctx) == '')
 			return element.name
 		else
 			return "${getNSPrefix(element, ctx)}:${element.name}"

--- a/core/src/test/groovy/com/predic8/schema/UnqualifiedTest.groovy
+++ b/core/src/test/groovy/com/predic8/schema/UnqualifiedTest.groovy
@@ -79,11 +79,11 @@ class UnqualifiedTest extends GroovyTestCase{
     schema.getElement('address').create(creator, new RequestTemplateCreatorContext())
     def request = strWriter.toString()
     assert request =~ /<.*?:address/   
-    assert request =~ /<name/
-    assert request =~ /<location/
-    assert request =~ /<city/
-    assert request =~ /<phone/    
-    assert request =~ /<numbers/    
+    assert request =~ /<.*?:name/
+    assert request =~ /<.*?:location/
+    assert request =~ /<.*?:city/
+    assert request =~ /<.*?:phone/    
+    assert request =~ /<.*?:numbers/    
   }
   
 }

--- a/core/src/test/groovy/com/predic8/wstool/creator/NamespacesInRequestTemplateCreatorTest.groovy
+++ b/core/src/test/groovy/com/predic8/wstool/creator/NamespacesInRequestTemplateCreatorTest.groovy
@@ -64,7 +64,7 @@ class NamespacesInRequestTemplateCreatorTest extends GroovyTestCase{
     wsdl.getInputElementForOperation('ArticleServicePT', 'create').create(creator, new RequestTemplateCreatorContext())
     def request = strWriter.toString()
     assert request =~ /<ns1:create/   
-    assert request =~ /<article/
+    assert request =~ /<ns1:article/
     assert request =~ /<ns2:name/
     assert request =~ /<ns2:description/
     assert request =~ /<ns2:price/


### PR DESCRIPTION
This is probably still not perfect. However, sending a request with a prefixed root and un-prefixed child element to a web-service does _not_ work for me. And with this change, child elemnts are also prefixed, and the service call I am testing works now.

I tested this by generating a request for a webservice I am working on and then submitting it, using a IntellIJ .http file that I generated using the SOARequestCreator.createRequest() util method.

After this commit, the resulting request looks like this and works:

    <s11:Envelope xmlns:s11='http://schemas.xmlsoap.org/soap/envelope/'>
      <s11:Body>
        <ns1:GetBusinessObject xmlns:ns1='http://client.example.com/xyz/v1'>
          <!-- from 0 to unbounded -->
          <ns1:objectId>0</ns1:objectId>
        </ns1:GetBusinessObject>
      </s11:Body>
    </s11:Envelope>

Before this commit, the resulting request looks like this and does not work - the service implementation code sees an empty list [] of "objectId"s instead of [1]:

    <s11:Envelope xmlns:s11='http://schemas.xmlsoap.org/soap/envelope/'>
      <s11:Body>
        <ns1:GetBusinessObject xmlns:ns1='http://client.example.com/xyz/v1'>
          <!-- from 0 to unbounded -->
          <objectId>0</objectId>
        </ns1:GetBusinessObject>
      </s11:Body>
    </s11:Envelope>

FTR, the IntelliJ "request" in the test-service.http file I use, looks like this:

    POST http://localhost:12345/xyz/XyzV1
    Content-Type: text/xml

    <s11:Envelope xmlns:s11='http://schemas.xmlsoap.org/soap/envelope/'>
    ...
    </s11:Envelope>